### PR TITLE
Make a better guess for the default websocket URL

### DIFF
--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -75,5 +75,5 @@
                                                   (.dispatchEvent (.querySelector js/document "body")
                                                                   (js/CustomEvent. "figwheel.js-reload"
                                                                                    (js-obj "detail" url))))
-                                :websocket-url "ws:localhost:3449/figwheel-ws" }
+                                :websocket-url (str "ws:" js/location.host "/figwheel-ws")}
                               opts))))


### PR DESCRIPTION
This makes figwheel work by default when someone has the figwheel server running on something other than localhost:3449.

`location.host` includes the port.

I tested this by cleaning out my compiled CLJS files and confirming that I no longer need to pass a `:websocket-url` to get the figwheel client to connect.
