### PR TITLE
Use 'ws://' instead of 'ws:' for compatibility with IE

### DIFF
--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -146,6 +146,6 @@
                                                   (.dispatchEvent (.querySelector js/document "body")
                                                                   (js/CustomEvent. "figwheel.js-reload"
                                                                                    (js-obj "detail" url))))
-                                :websocket-url (str "ws:" js/location.host "/figwheel-ws")}
+                                :websocket-url (str "ws://" js/location.host "/figwheel-ws")}
                               opts))))
 


### PR DESCRIPTION
"ws:hostname" works in Firefox and Chrome, but IE11 throws a a `SyntaxError` with no error message if you try to construct a `WebSocket` with a "ws:hostname" URL.

After this change, lein-figwheel appears to be working in IE11.
