### PR TITLE
Add explicit multi-server details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,20 @@ Like so:
   :jsload-callback (fn [] (print "reloaded")))
 ```
 
+Note that you will still need to run the figwheel server in addition to 
+your development app server if you wish to continue utilizing figwheel.
+
+For example, you could run figwheel in one terminal...
+
+```
+$ lein figwheel
+```
+
+and run your app server of choice in another...
+
+```
+$ lein ring server
+```
 
 ## Writing reloadable code
 


### PR DESCRIPTION
I know this was implied in the statement about hosting the app and static assets, but it's just not very clear. 
