### PR TITLE
Fix the `options` arg to `route/resources`.

### DIFF
--- a/support/src/figwheel/core.clj
+++ b/support/src/figwheel/core.clj
@@ -60,7 +60,7 @@
   (run-server
    (routes
     (GET "/figwheel-ws" [] (reload-handler server-state))
-    (route/resources "/" :root http-server-root)
+    (route/resources "/" {:root http-server-root})
     (or ring-handler (fn [r] false))
     (GET "/" [] (resource-response "index.html" {:root http-server-root}))
     (route/not-found "<h1>Page not found</h1>"))


### PR DESCRIPTION
A small fix to get the figwheel web server to return the appropriate resource objects, when `http-server-root` points to something other than "public".
