### PR TITLE
Show correct use of :server-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ In your `project.clj` you can add the following configuration parameters:
 ```clojure
 :figwheel {
    :http-server-root "public" ;; this will be in resources/
-   :port 3449                 ;; default
+   :server-port 3449          ;; default
 
    ;; CSS reloading (optional)
    ;; :css-dirs has no default value 


### PR DESCRIPTION
:figwheel config expects :server-port rather than :port. Updated readme accordingly.
