### PR TITLE
Execute on-jsload callback outside of core.async context.

### DIFF
--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -57,8 +57,8 @@
      (when (not-empty res)
        (.debug js/console "Figwheel: loaded these files")
        (.log js/console (prn-str (map :file res)))
-       (<! (timeout 10)) ;; wait a beat before callback
-       (apply on-jsload [res])))))
+       ;; wait a beat before running callback outside of go's exception handler.
+       (js/setTimeout #(apply on-jsload [res]) 10)))))
 
 ;; CSS reloading
 


### PR DESCRIPTION
Otherwise the handling of the go block catches the exception.
This is annoying for debugging because:

1) You must enable "Break on uncaught exceptions"
2) Stack traces are frequently lost
