### PR TITLE
Add `compiler-env` arg to `autobuild`

### DIFF
--- a/sidecar/src/figwheel_sidecar/auto_builder.clj
+++ b/sidecar/src/figwheel_sidecar/auto_builder.clj
@@ -43,7 +43,7 @@
                             (when-let [s (cljs.analyzer/error-message warning-type extra)]
                                 (fig/compile-warning-occured figwheel-state' (cljs.analyzer/message env s)))))
         warning-handlers (conj cljs.analyzer/*cljs-warning-handlers* warning-handler)
-        compiler-env    (cljs.env/default-compiler-env build-options)]
+        compiler-env'    (or cljs.env/*compiler* (cljs.env/default-compiler-env build-options))]
     (reset! server-kill-switch (:http-server figwheel-state'))
 
     (loop [dependency-mtimes {}]
@@ -56,7 +56,7 @@
               (println (str "Compiling \"" (:output-to build-options) "\" from " (pr-str src-dirs) "..."))
               (flush)
               (let [started-at (System/currentTimeMillis)
-                    additional-changed-ns (cbuild/build-source-paths src-dirs build-options compiler-env)]
+                    additional-changed-ns (cbuild/build-source-paths src-dirs build-options compiler-env')]
                 (println (green (str "Successfully compiled \"" (:output-to build-options) "\" in " (elapsed started-at) ".")))
                 (fig/check-for-changes figwheel-state' dependency-mtimes new-mtimes additional-changed-ns)))
             (catch Throwable e


### PR DESCRIPTION
Hi,

I saw your comment on plexus/chestnut#49 indicating that figwheel can now be started directly from a REPL - great news! I think being able to pass in an atom for figwheel to use as the compiler environment here would be really useful. The first immediate use I can think of would be to integrate with tooling that relies on introspection of the compiler environment (e.g. autocompletion/documentation lookup/the ns browser in CIDER). I also think it would be interesting to experiment with having both a CLJS REPL and Figwheel simultaneously running but sharing the same compiler env (obviously the caveats of writing reloadable code will still apply to anything evaluated at the REPL, and there are probably other issues around doing this).

I've toyed around with this change combined with this fork of cider-nrepl: https://github.com/cichli/cider-nrepl/compare/set-cljs-compiler-env and have found the following code (adapted from [Chestnut](https://github.com/plexus/chestnut/blob/master/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj#L22)) works beautifully:

``` clojure
(defn start-figwheel []
  (let [cljsbuild-opts (get-in (leiningen.core.project/read) [:cljsbuild :builds :app])
        src-dirs (:source-paths cljsbuild-opts)
        build-opts (:compiler cljsbuild-opts)
        compiler-env (cljs.env/default-compiler-env build-opts)]
    (future
      (print "Starting figwheel.\n")
      (figwheel/autobuild ["src/cljs"]
                          build-opts
                          {}
                          :compiler-env compiler-env))
    (when-let [cider-compiler-env (resolve 'cider.nrepl.middleware.util.cljs/*compiler-env*)]
      (alter-var-root cider-compiler-env (constantly compiler-env)))
    compiler-env))
```

Now I can have autocompletion and documentation lookup in emacs, that updates automatically as figwheel reloads, without needing to ever start a CLJS REPL or manually load/eval any code!

It might also be useful (from a tooling perspective) to allow callers to:
- override `warning-handler`
- override the current exception handler
- override logging in general (see plexus/chestnut#58)
- possibly pass callbacks for compilation start/completion (as you mention in the comments in the function)

Thoughts?
