### PR TITLE
Canonicalize both paths when checking config. fix #73

### DIFF
--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -17,7 +17,7 @@
 (defn relativize-resource-paths
   "Relativize to the local root just in case we have an absolute path"
   [resource-paths]
-  (mapv #(string/replace-first (norm-path %)
+  (mapv #(string/replace-first (norm-path (.getCanonicalPath (io/file %)))
                                (str (norm-path (.getCanonicalPath (io/file ".")))
                                     "/") "") resource-paths))
 


### PR DESCRIPTION
The change just insures that both the resource path and the root path are acquired by calling getCanonicalPath, so that on Windows the drive letters are consistent.