### PR TITLE
ensure-container always returns a map

### DIFF
--- a/support/src/figwheel/client/heads_up.cljs
+++ b/support/src/figwheel/client/heads_up.cljs
@@ -67,10 +67,10 @@
         (set! (.-innerHTML el) (str clojure-symbol-svg))
         (.appendChild el (node :div {:id content-id}))
         (-> (.-body js/document)
-            (.appendChild el)))
-      { :container-el    (.getElementById js/document cont-id)
-        :content-area-el (.getElementById js/document content-id) }
-      )))
+            (.appendChild el))))
+    { :container-el    (.getElementById js/document cont-id)
+      :content-area-el (.getElementById js/document content-id) }
+      ))
 
 (defn set-style! [{:keys [container-el]} st-map]
   (mapv


### PR DESCRIPTION
I was getting  `Uncaught TypeError: Cannot read property 'style' of null` on all of the successful reloads for a big project. Even thought I couldn't reproduce the error in a minimal working case, it might be related to  #70. 

The error happens when `ensure-container` returns a bare HTMLDivTag Object instead of the map `{:container-el ...}` since `set-syle!` expects a map. When I moved `{:container-el ...}` outside of the `if-not` the error went away.

Hope this is correct.