### PR TITLE
Fixing old style REPL (without nrepl)

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -431,8 +431,8 @@
 (defn run-autobuilder [{:keys [figwheel-options all-builds build-ids] :as options}]
   (binding [*autobuild-env* (create-autobuild-env options)]
     (start-nrepl-server figwheel-options *autobuild-env*)
-    (if (or (= (:repl figwheel-options) false)
-            (nil? (:nrepl-port figwheel-options)))
+    (if (or (false? (:repl figwheel-options))
+            (not (nil? (:nrepl-port figwheel-options))))
       (when (figwheel-sidecar.auto-builder/autobuild-ids *autobuild-env*)
         (loop [] (Thread/sleep 30000) (recur)))
       (repl-switching-loop))))


### PR DESCRIPTION
I'm not sure if this pull request is correct since it seems too simple.

After bumping up to version `2.5.0` the auto-build process would work but not the old REPL. After looking at `run-autobuilder` it seems to me that the conditional is wrong: if the `:nrepl-port` option is not set, it won't start a REPL. Those who are not using nrepl would never set `:nrepl-port` but still expect a REPL. 

After negating the condition the old REPL worked. I also tested the new nrepl server from Emacs with Cider, by setting `:nrepl 7888` and it worked. Great job, it worked without glitches! Figwheel is moving very fast :)

I hope my understanding of the code is correct and this helps.

Thanks!