### PR TITLE
Aligns REPL Figwheel control comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,12 +382,13 @@ The REPL has the following control functions:
 
 ```
 Figwheel Controls:
- (stop-autobuild)           ;; stops Figwheel autobuilder
- (start-autobuild [id ...]) ;; starts autobuilder focused on optional ids
- (switch-to-build id ...)   ;; switches autobuilder to different build
- (reset-autobuild)          ;; stops, cleans, and starts autobuilder
- (build-once [id ...])      ;; builds source once time
- (clean-build [id ..])      ;; deletes compiled cljs target files
+ (stop-autobuild)            ;; stops Figwheel autobuilder
+ (start-autobuild [id ...])  ;; starts autobuilder focused on optional ids
+ (switch-to-build id ...)    ;; switches autobuilder to different build
+ (reset-autobuild)           ;; stops, cleans, and starts autobuilder
+ (build-once [id ...])       ;; builds source one time
+ (clean-builds [id ..])      ;; deletes compiled cljs target files
+ (fig-status)                ;; displays current state of system
 ```
 
 These functions are special functions that poke through the
@@ -409,8 +410,12 @@ autobuilder on the provided build id `example`. It will also make
 `start-autobuild` and `switch-to-build` are the only functions that
 update the build-id set.
 
-`clean-build` and `build-once` both allow you to do one off builds and
+`clean-builds` and `build-once` both allow you to do one off builds and
 cleans.  They do not alter the implicit build ids.
+
+`fig-status` displays information on the current Figwheel system state,
+including whether the autobuilder is running, which build ids are in
+focus, and the number of client connections.
 
 
 #### Rewriting asset request urls

--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -342,16 +342,16 @@
 
 (defn repl-function-docs  []
   "Figwheel Controls:
-          (stop-autobuild)           ;; stops Figwheel autobuilder
-          (start-autobuild [id ...]) ;; starts autobuilder focused on optional ids
-          (switch-to-build id ...)   ;; switches autobuilder to different build
-          (reset-autobuild)          ;; stops, cleans, and starts autobuilder
-          (build-once [id ...])      ;; builds source once time
-          (clean-builds [id ..])      ;; deletes compiled cljs target files
-          (fig-status)               ;; displays current state of system
+          (stop-autobuild)                ;; stops Figwheel autobuilder
+          (start-autobuild [id ...])      ;; starts autobuilder focused on optional ids
+          (switch-to-build id ...)        ;; switches autobuilder to different build
+          (reset-autobuild)               ;; stops, cleans, and starts autobuilder
+          (build-once [id ...])           ;; builds source one time
+          (clean-builds [id ..])          ;; deletes compiled cljs target files
+          (fig-status)                    ;; displays current state of system
           (add-dep [org.om/om \"0.8.1\"]) ;; add a dependency. very experimental
   Switch REPL build focus:
-          :cljs/quit                 ;; allows you to switch REPL to another build
+          :cljs/quit                      ;; allows you to switch REPL to another build
     Docs: (doc function-name-here)
     Exit: Control+C or :cljs/quit
  Results: Stored in vars *1, *2, *3, *e holds last exception object")


### PR DESCRIPTION
Hi.

Just some cosmetic edits — aligns the REPL control comments, updates `clean-build` to `clean-builds` in the README, and adds a blurb on `fig-status`.

Great tool. Thanks for taking the time to make this.

All the best,
O-I 