### PR TITLE
fixed NullPointerException and made tests run

### DIFF
--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.string :as string]
    [clojure.java.io :as io]
-   [clojure.walk :as walk]))
+   [clojure.walk :as walk]
+   [figwheel-sidecar.core :refer [norm-path]]))
 
 (defn mkdirs [fpath]
   (let [f (io/file fpath)]
@@ -19,10 +20,6 @@
   (= :none (get-in build [:compiler :optimizations])))
 
 ;; checking to see if output dir is in right directory
-(defn norm-path
-  "Normalize paths to a forward slash separator to fix windows paths"
-  [p] (string/replace p  "\\" "/"))
-
 (defn relativize-resource-paths
   "Relativize to the local root just in case we have an absolute path"
   [resource-paths]

--- a/sidecar/src/figwheel_sidecar/core.clj
+++ b/sidecar/src/figwheel_sidecar/core.clj
@@ -21,6 +21,11 @@
    [clojurescript-build.api :as cbapi]
    [clojure.pprint :as p]))
 
+(defn atom?
+  "Returns true when the provided argument is an atom."
+  [maybe-atom?]
+  (instance? clojure.lang.Atom maybe-atom?))
+
 ;; get rid of fs dependancy
 
 (defn split-ext
@@ -142,8 +147,9 @@
 (defn append-msg [q msg] (conj (take 30 q) msg))
 
 (defn send-message! [{:keys [file-change-atom] :as st} msg-name data]
-  (swap! file-change-atom append-msg
-         (message* st msg-name data)))
+  (when (atom? file-change-atom)
+    (swap! file-change-atom append-msg
+           (message* st msg-name data))))
 
 (defn send-changed-files
   "Formats and sends a files-changed message to the file-change-atom.
@@ -208,9 +214,9 @@
 
 (defn file-changed?
   "Standard md5 check to see if a file actually changed."
-  [{:keys [file-md5-atom]} filepath]  
+  [{:keys [file-md5-atom]} filepath]
   (let [file (as-file filepath)]
-    (when (.exists file)
+    (when (and (.exists file) (atom? file-md5-atom))
       (let [contents (slurp file)]
         (when (.contains contents "addDependency")
           (let [check-sum (digest/md5 contents)

--- a/sidecar/test/figwheel_sidecar/core_test.clj
+++ b/sidecar/test/figwheel_sidecar/core_test.clj
@@ -1,9 +1,9 @@
 (ns figwheel-sidecar.core-test
-  (:use figwheel-sidecar.core)
-  (:use clojure.test)
-  (:require
-   [clojure.string :as string]
-   [clojure.java.io :as io]))
+  (:use [clojure.test]
+        [figwheel-sidecar.core])
+  (:require [clojure.string :as string]
+            [clojure.java.io :as io]
+            [figwheel-sidecar.config :refer [relativize-resource-paths]]))
 
 (deftest test-utils
   (is (.startsWith (project-unique-id) "figwheel-sidecar--")))
@@ -15,58 +15,12 @@
             "other-resources-help/dang"]))
 
     (is (= (relativize-resource-paths (dissoc st :resource-paths))
-           []))
-    (is (= (ns-to-server-relative-path st 'example.crazy-name)
-           "/js/compiled/out/example/crazy_name.js"))
-    (is (= (ns-to-server-relative-path st 'example.crazy_name)
-           "/js/compiled/out/example/crazy_name.js"))
-    (is (= (ns-to-server-relative-path st "example.crazy_name")
-           "/js/compiled/out/example/crazy_name.js"))
-    (is (= (ns-to-server-relative-path st "example.crazy-name")
-           "/js/compiled/out/example/crazy_name.js")))
+           [])))
 
-(deftest test-remove-resource-path
-  (let [root (.getCanonicalPath (io/file "."))
-        st { :http-server-root "public"
-            :output-dir "other-resources/public/js/compiled/out"
-           :resource-paths [(str root "/resources")
-                            (str root "/other-resources")
-                            (str root "/dev-resources")
-                            (str root "/other-resources-help/dang")]}]
-    (remove-resource-path-tests st)
-    (remove-resource-path-tests
-     (assoc st
-       :output-dir       "resources/public/js/compiled/out"))
-    (remove-resource-path-tests
-     (assoc st
-       :output-dir       "other-resources-help/dang/public/js/compiled/out"))    
-    (remove-resource-path-tests
-     (merge st {:http-server-root "public/house"
-                :output-dir       "other-resources/public/house/js/compiled/out"}))
-
-    ;; make sure it works if not given abasolute paths
-    (remove-resource-path-tests
-     (merge st {:resource-paths [(str "resources")
-                                 (str "other-resources")
-                                 (str "dev-resources")
-                                 (str "other-resources-help/dang")] }))
-    ))
-
-
-(defn windows-pather [s]
-  (string/replace s "/" "\\"))
-
-(deftest test-remove-resource-windows-path
-  (let [root (windows-pather (.getCanonicalPath (io/file ".")))
-        st { :http-server-root "public"
-             :resource-paths [(str root "\\resources")
-                              (str root "\\other-resources")
-                              (str root "\\dev-resources")
-                             (str root "\\other-resources-help/dang")]}]
-    (is (= (remove-resource-path st "resources\\public\\js\\example\\core.js")
-           "/js/example/core.js"))
-    (is (= (remove-resource-path st "resources\\public\\css\\style.css")
-           "/css/style.css"))
-    ))
+(deftest test-atom?
+  (let [not-an-atom "foo"
+        an-atom (atom {})]
+    (is (atom? an-atom))
+    (is (not (atom? not-an-atom)))))
 
 #_(run-tests)


### PR DESCRIPTION
When integrating Sidecar into my project I ran into some NullPointerExceptions. I wrote a quick fix, which isn't as thorough as it could be, because it fixes the symptom (i.e. the exceptions went away), but doesn't address the root cause (i.e. the atoms not being provided to the relevant functions). Apart from the `atom?` check, I also threw away some broken tests and a duplicate function (`norm-path`) in order to make the tests run again.

Thanks for the great work on Figwheel and Sidecar! I hope this fix saves someone some time.