### PR TITLE
start-nrepl-server also writes a `.nrepl-port` file now

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -426,7 +426,8 @@
     (nrepl-serv/start-server
      :port (:nrepl-port figwheel-options)
      :handler (apply nrepl-serv/default-handler
-                     (conj (map resolve cider/cider-middleware) #'pback/wrap-cljs-repl)))))
+                     (conj (map resolve cider/cider-middleware) #'pback/wrap-cljs-repl)))
+    (spit (doto (io/file ".nrepl-port") .deleteOnExit) (:nrepl-port figwheel-options))))
 
 (defn create-autobuild-env [{:keys [figwheel-options all-builds build-ids]}]
   (let [logfile-path (or (:server-logfile figwheel-options) "figwheel_server.log")


### PR DESCRIPTION
Hi,

first of all thank you for creating this wonderful tool. I'm using it in conjunction with nrepl. I've extended `start-nrepl-server`, so that it also writes a `.nrepl-port` file now, which allows cider and (probably) other Clojure IDEs to discover the running nrepl process inside figwheel.

The implementation assumes the use of Leiningen (like `figwheel-sidecar.core/project-unique-id`). While `leiningen.repl` does some extra steps to write the `.nrepl-port` file, the implementation here should be sufficient. Maybe one complication would be that the `.nrepl-port` file will be overwritten by any other `lein repl` process (and the other way around), which is started for the same project where figwheel (with nrepl enabled) runs. However I would say that the convenience improvement is worth the change.

Best regards

Max