### PR TITLE
add foreign-libs reloading suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Here is a [live demo of figwheel](https://www.youtube.com/watch?v=KZjFVdU8VLI)
 See the introductory blog post [here](http://rigsomelight.com/2014/05/01/interactive-programming-flappy-bird-clojurescript.html).
 
 ####Current version:
-[![Clojars Project](http://clojars.org/lein-figwheel/latest-version.svg)](http://clojars.org/lein-figwheel) 
+[![Clojars Project](http://clojars.org/lein-figwheel/latest-version.svg)](http://clojars.org/lein-figwheel)
 
 ![Figwheel heads up example](https://s3.amazonaws.com/bhauman-blog-images/figwheel_image.png)
 
-## Features 
+## Features
 
 #### Live code reloading
 
@@ -36,6 +36,10 @@ handler into the figwheel server.
 #### Live CSS reloading
 
 Figwheel will reload your CSS live as well.
+
+#### Live Foreign JavaScript reloading
+
+Figwheel will reload foreign-libs too...whether these libs are suitable to reloading or not is up to you.
 
 #### Heads up display
 
@@ -132,11 +136,16 @@ Here is an example:
 
 ```clojure
 :cljsbuild {
-  :builds [ { :id "example" 
+  :builds [ { :id "example"
               :source-paths ["src/"]
               :compiler { :output-to "resources/public/js/compiled/example.js"
                           :output-dir "resources/public/js/compiled/out"
                           :externs ["resources/public/js/externs/jquery-1.9.js"]
+
+                          ;; needs :foreign-dirs in fw options, see server config below
+                          :foreign-libs [{:file "resources/public/js/foreign/jquery.js"
+                                          :provides ["jq"]}]
+
                           :optimizations :none
                           :source-map true } } ]
 }
@@ -178,10 +187,19 @@ In your `project.clj` you can add the following configuration parameters:
    :server-port 3449          ;; default
 
    ;; CSS reloading (optional)
-   ;; :css-dirs has no default value 
+   ;; :css-dirs has no default value
    ;; if :css-dirs is set figwheel will detect css file changes and
    ;; send them to the browser
    :css-dirs ["resources/public/css"]
+
+   ;; foreign js reloading (optional)
+   ;; :foreign-dirs has no default value
+   ;; if :foreign-dirs is set figwheel will detect file changes and
+   ;; send them to the browser if required
+   :foreign-dirs ["resources/public/js/foreign"]
+
+
+
 
    ;; Server Ring Handler (optional)
    ;; if you want to embed a ring handler into the figwheel http-kit
@@ -201,9 +219,9 @@ In your `project.clj` you can add the following configuration parameters:
    ;; :repl false
 
    ;; to configure a different figwheel logfile path
-   ;; :server-logfile "tmp/logs/figwheel-logfile.log" 
-   
-} 
+   ;; :server-logfile "tmp/logs/figwheel-logfile.log"
+
+}
 ```
 
 ## Client side usage
@@ -252,7 +270,7 @@ In keeping with the previous examples you would put this into your
   :on-jsload (fn [] (print "reloaded"))
 
   ;; The heads up display is enabled by default
-  ;; to disable it: 
+  ;; to disable it:
   ;; :heads-up-display false
 
   ;; when the compiler emits warnings figwheel
@@ -268,7 +286,7 @@ In keeping with the previous examples you would put this into your
 ```
 
 The call to `start` is idempotent and can be called many
-times safely. 
+times safely.
 
 Whole files will be reloaded on change so we have to make sure that
 we [write reloadable code](https://github.com/bhauman/lein-figwheel#writing-reloadable-code).
@@ -310,7 +328,7 @@ To force a file to reload on every change:
 ### Using your own server
 
 You do not have to use the figwheel server to host your app and its
-static assets. You can use your own server. 
+static assets. You can use your own server.
 
 To use your own server simply navigate to your server url for the page
 that is hosting your ClojureScript app.
@@ -327,7 +345,7 @@ Like so:
 })
 ```
 
-Note that you will still need to run the figwheel server in addition to 
+Note that you will still need to run the figwheel server in addition to
 your development app server if you wish to continue utilizing figwheel.
 
 For example, you could run figwheel in one terminal...
@@ -454,13 +472,13 @@ Clojure REPL like so:
 
 ;; you can stop the building process like so:
 (auto/stop-autobuild! fig-builder)
-                                        
+
 ;; you can then restart the watching and building process with a
 ;; different config etc.
 
 ```
 
-## Resources 
+## Resources
 
 [Figwheel keep om turning](http://blog.michielborkent.nl/blog/2014/09/25/figwheel-keep-Om-turning/) is an excellent blog post on how to use figwheel with Om.  It's also worth reading if you aren't using Om.
 
@@ -479,21 +497,21 @@ browser can reload them.
 
 The main motivation for lein-figwheel is to allow for the interactive
 development of ClojureScript. Figwheel doesn't provide this out of the
-box, **the developer has to take care to make their code reloadable**. 
+box, **the developer has to take care to make their code reloadable**.
 
 ## Writing reloadable code
 
-Figwheel relies on having files that can be reloaded. 
+Figwheel relies on having files that can be reloaded.
 
 Reloading works beautifully on referentially transparent code and
 code that only defines behavior without bundling state with the
-behavior. 
+behavior.
 
 If you are using React or Om it's not hard to write reloadable code,
 in fact you might be doing it already.
 
 There are several coding patterns to look out for when writing
-reloadable code. 
+reloadable code.
 
 One problematic pattern is top level definitions that have local
 state.
@@ -544,8 +562,8 @@ APIs directly has always been really difficult. For instance if we make
 it so that these hooks are only executed once, like so:
 
 ```clojure
-(defonce setup-stuff 
-  (do 
+(defonce setup-stuff
+  (do
      (.click ($ "a.button") (fn [e] (print "clicked button")))))
 ```
 
@@ -555,9 +573,9 @@ have the listener bound to them.
 
 You can fix this by using an event delegation strategy as so:
 
-```clojure  
-(defonce setup-stuff 
-  (do 
+```clojure
+(defonce setup-stuff
+  (do
      (.on ($ "div#app") "click" "a.button" (fn [e] (print "clicked button")))))
 ```
 
@@ -566,18 +584,18 @@ code in the setup up block and see your changes take affect.
 
 If you are not using React and you want to build things this way and
 have reloadable code we need to create `setup` and `teardown`
-functions to be invoked on code reload.  
+functions to be invoked on code reload.
 
-```clojure  
+```clojure
 (defn setup []
    (.on ($ "div#app") "click" "a.button" (fn [e] (print "clicked button"))))
 
 (defn teardown []
    (.off ($ "div#app") "click" "a.button")
 
-;; hook in the  
+;; hook in the
 (fw/start {
-  :on-jsload (fn [] 
+  :on-jsload (fn []
                (teardown)
                (setup))
 })

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -10,7 +10,7 @@
     :dev {
       :dependencies [[cljsbuild "1.0.4"]]
       :plugins [[lein-cljsbuild "1.0.4"]]}}
-  
+
   :scm { :name "git"
         :url "https://github.com/bhauman/lein-figwheel"
         :dir "plugin"}

--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -26,9 +26,9 @@
 ;; well this is private in the leiningen.cljsbuild ns
 (defn- run-local-project [project crossover-path builds requires form]
   (let [project' (-> project
-                     (update-in [:dependencies] conj ['figwheel-sidecar figwheel-sidecar-version]) 
+                     (update-in [:dependencies] conj ['figwheel-sidecar figwheel-sidecar-version])
                      (subproject/make-subproject crossover-path builds)
-                     #_(update-in [:dependencies] #(filter (fn [[n _]] (not= n 'cljsbuild)) %)))] 
+                     #_(update-in [:dependencies] #(filter (fn [[n _]] (not= n 'cljsbuild)) %)))]
     (leval/eval-in-project project'
      `(try
         (do
@@ -72,7 +72,9 @@ See https://github.com/emezeske/lein-cljsbuild/blob/master/doc/CROSSOVERS.md for
                                     builds)))
         figwheel-options (fc/prep-options
                           (merge
-                           { :http-server-root "public" }
+                           {:http-server-root "public"
+                            :foreign-libs (:foreign-libs (:compiler (first (filter #(= (:id %) (or (first build-ids) "dev")) builds)))) ;; assumes "dev" build if no arg, could be problem
+                            :output-dir (:output-dir (:compiler (first builds)))}
                            (dissoc (:figwheel project) :builds)
                            (select-keys project [:resource-paths])))
         errors           (fc/check-config figwheel-options

--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -11,16 +11,16 @@
    [org.clojure/clojurescript "0.0-2850"
     :exclusions [org.apache.ant/ant]]
    [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-   [com.cemerick/pomegranate "0.3.0"]   
+   [com.cemerick/pomegranate "0.3.0"]
    [http-kit "2.1.16"]
    [ring-cors "0.1.4"]
    [compojure "1.1.7"]
    [clj-stacktrace "0.2.7"]
    [cljsbuild "1.0.4"]
-   
+
    [com.cemerick/piggieback "0.1.5"]
    [cider/cider-nrepl "0.8.2"]
-   
+
    [clojurescript-build "0.1.5"]
    [watchtower "0.1.1"]
    [digest "1.4.3"]])

--- a/sidecar/src/figwheel_sidecar/auto_builder.clj
+++ b/sidecar/src/figwheel_sidecar/auto_builder.clj
@@ -7,7 +7,7 @@
    [cljs.analyzer :as ana]
    [cljs.env]
    #_[clj-stacktrace.repl]
-   [clojure.stacktrace :as stack]   
+   [clojure.stacktrace :as stack]
    [clojurescript-build.core :as cbuild]
    [clojurescript-build.auto :as auto]
    [clojure.java.io :as io]
@@ -85,7 +85,9 @@
    {:builds  builds
     :builder (builder figwheel-server)
     :each-iteration-hook (fn [_ build]
-                           (fig/check-for-css-changes figwheel-server))}))
+                           (do
+                             (fig/check-for-foreign-changes figwheel-server)
+                             (fig/check-for-css-changes figwheel-server)))}))
 
 (defn check-autobuild-config [all-builds build-ids figwheel-server]
   (let [builds (config/narrow-builds* all-builds build-ids)]
@@ -109,8 +111,50 @@
                          :build-options build-options}]
                :figwheel-server (fig/start-server figwheel-options)}))
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 (comment
-  
+
   (def builds [{ :id "example"
                  :source-paths ["src" "../support/src"]
                  :build-options { :output-to "resources/public/js/compiled/example.js"
@@ -126,17 +170,17 @@
                         builds))
 
   (def figwheel-server (fig/start-server))
-  
+
   (fig/stop-server figwheel-server)
-  
+
   (def bb (autobuild* {:builds env-builds
                        :figwheel-server figwheel-server}))
-  
+
   (auto/stop-autobuild! bb)
 
   (fig-repl/eval-js figwheel-server "1 + 1")
 
   (def build-options (:build-options (first builds)))
-  
+
   #_(cljs.repl/repl (repl-env figwheel-server) )
 )


### PR DESCRIPTION
I wanted to mutate a JS package from node but using my own script tags caused async dependency issues, so I needed this.

Basically this just copies your approach to reloading CSS changes. 
     1) It grabs foreign-libs info at figwheel-options creation in plugin figwheel.clj
     2) It spoofs the namespace with the :provide info when sending the reload msg from sidecar.core
     3) mostly uses existing machinery in client

One change in client is client.file-reloading/reload-foreign which is same as reload-base but without call to add-cache-buster...I could not figure out how this works so I simply removed it and it worked fine. This might be a problem I don't know.

A possible problem is where people do not have a "dev" build :id and then call lein figwheel without passing an :id. I am not sure how to account for that
