### PR TITLE
Improved error reporting

### DIFF
--- a/sidecar/src/figwheel_sidecar/auto_builder.clj
+++ b/sidecar/src/figwheel_sidecar/auto_builder.clj
@@ -63,7 +63,8 @@
     #_(clj-stacktrace.repl/pst+ exception)
     (fig/compile-error-occured
       (merge-build-into-server-state figwheel-server build)
-      exception)))
+      exception
+      cause)))
 
 (defn warning [builder warn-handler]
   (fn [build]

--- a/sidecar/src/figwheel_sidecar/auto_builder.clj
+++ b/sidecar/src/figwheel_sidecar/auto_builder.clj
@@ -45,14 +45,25 @@
        new-mtimes
        additional-changed-ns))))
 
+(defmulti report-exception (fn [exception cause] (:type cause)))
+
+(defmethod report-exception :reader-exception [e {:keys [file line column]}]
+  (println (format "ERROR: %s on file %s, line %d, column %d"
+                   (some-> e (.getCause) (.getMessage))
+                   file line column)))
+
+(defmethod report-exception :default [e _]
+  (stack/print-stack-trace e 30))
+
 (defn handle-exceptions [figwheel-server {:keys [build-options exception id] :as build}]
   (println (auto/red (str "Compiling \"" (:output-to build-options) "\" failed.")))
-  (stack/print-stack-trace exception 30)
-  (flush)
-  #_(clj-stacktrace.repl/pst+ exception)
-  (fig/compile-error-occured
-   (merge-build-into-server-state figwheel-server build)
-   exception))
+  (let [cause (ex-data (.getCause exception))]
+    (report-exception exception cause)
+    (flush)
+    #_(clj-stacktrace.repl/pst+ exception)
+    (fig/compile-error-occured
+      (merge-build-into-server-state figwheel-server build)
+      exception)))
 
 (defn warning [builder warn-handler]
   (fn [build]

--- a/sidecar/src/figwheel_sidecar/core.clj
+++ b/sidecar/src/figwheel_sidecar/core.clj
@@ -406,14 +406,15 @@
 
 ;; compile error occured
 
-(defn compile-error-occured [st exception]
+(defn compile-error-occured [st exception cause]
   (let [parsed-exception (parse-exception exception)
         formatted-exception (let [out (java.io.ByteArrayOutputStream.)]
                               (pst-on (io/writer out) false exception)
                               (.toString out))]
     (send-message! st :compile-failed
                    { :exception-data parsed-exception
-                     :formatted-exception formatted-exception })))
+                     :formatted-exception formatted-exception
+                     :cause cause })))
 
 (defn compile-warning-occured [st msg]
   (send-message! st :compile-warning { :message msg }))

--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -173,10 +173,10 @@
       (compile-refail-state? msg-names)
       (do
         (<! (heads-up/clear))
-        (<! (heads-up/display-error (format-messages (:exception-data msg)))))
+        (<! (heads-up/display-error (format-messages (:exception-data msg)) (:cause msg))))
       
       (compile-fail-state? msg-names)
-      (<! (heads-up/display-error (format-messages (:exception-data msg))))
+      (<! (heads-up/display-error (format-messages (:exception-data msg)) (:cause msg)))
       
       (warning-append-state? msg-names)
       (heads-up/append-message (:message msg))
@@ -229,10 +229,12 @@
                     (js/CustomEvent. "figwheel.js-reload"
                                      (js-obj "detail" url)))))
 
-(defn default-on-compile-fail [{:keys [formatted-exception exception-data] :as ed}]
+(defn default-on-compile-fail [{:keys [formatted-exception exception-data cause] :as ed}]
   (utils/log :debug "Figwheel: Compile Exception")
   (doseq [msg (format-messages exception-data)]
     (utils/log :info msg))
+  (if cause
+    (utils/log :info (str "Error on file " (:file cause) ", line " (:line cause) ", column " (:column cause))))
   ed)
 
 (defn default-on-compile-warning [{:keys [message] :as w}]

--- a/support/src/figwheel/client/heads_up.cljs
+++ b/support/src/figwheel/client/heads_up.cljs
@@ -135,11 +135,15 @@
     (file-selector-div f ln msg)
     (str "<div>" msg "</div>")))
 
-(defn display-error [formatted-messages]
-  (let [[file-name file-line] (first (keep file-and-line-number formatted-messages))
+(defn display-error [formatted-messages cause]
+  (let [[file-name file-line file-column]
+        (if cause
+          [(:file cause) (:line cause) (:column cause)]
+          (first (keep file-and-line-number formatted-messages)))
         msg (apply str (map #(str "<div>" % "</div>") formatted-messages))]
     (display-heads-up {:backgroundColor "rgba(255, 161, 161, 0.95)"}
-                      (str (close-link) (heading "Compile Error") (file-selector-div file-name file-line msg)))))
+                      (str (close-link) (heading "Compile Error") (file-selector-div file-name file-line msg)
+                           (if cause (str "Error on file " (:file cause) ", line " (:line cause) ", column " (:column cause)))))))
 
 (defn display-system-warning [header msg]
   (display-heads-up {:backgroundColor "rgba(255, 220, 110, 0.95)" }


### PR DESCRIPTION
Hello,

This fixes #125 

Here are two changes which should improve how errors are displayed on console, browser console and on HUD.

First commit adds a special case to auto builder on how to handle exception from clojure reader. If reader exception is thrown, instead of stack trace, only an error message describing the problem is displayed with location info.

Second commit adds the exception data to the message sent to the client. The client will use the exception data, if available, to set attributes for `file-selector-div` and to display and additional line below exception message describing the location. The client also logs location info to console.

![Console](https://www.dropbox.com/s/hej7ewrin9dg1rf/Screenshot%20from%202015-04-16%2023%3A07%3A32.png?dl=1)
![HUD and browser console](https://www.dropbox.com/s/u9k2l9bht49va61/Screenshot%20from%202015-04-16%2023%3A07%3A11.png?dl=1)