### PR TITLE
Allow :nrepl-host option for binding nrepl to a non-localhost value

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -491,6 +491,7 @@
   (when (:nrepl-port figwheel-options)
     (nrepl-serv/start-server
      :port (:nrepl-port figwheel-options)
+     :bind (:nrepl-host figwheel-options)
      :handler (apply nrepl-serv/default-handler
                      (conj (map resolve cider/cider-middleware) #'pback/wrap-cljs-repl)))))
 


### PR DESCRIPTION
Tested locally, and it seems to work pretty well. Anywhere you can specify `:nrepl-port` you can also specify `:nrepl-host`, which will tell nrepl to accept connections from that hostname.