### PR TITLE
Only configure :websocket-url if :websocket-host is provided

### DIFF
--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -235,12 +235,13 @@
   (if (figwheel-build? build)
     (let [build (prep-build-for-figwheel-client build)]
       (if-not (get-in build [:figwheel :websocket-url]) ;; prefer 
-        (if-let [host (get-in build [:figwheel :websocket-host])]
-          (-> build
-            (update-in [:figwheel] dissoc :websocket-host)
-            (assoc-in [:figwheel :websocket-url]
-                      (str "ws://" host ":" (:server-port figwheel-server) "/figwheel-ws")))
-          build)
+        (let [host (or (get-in build [:figwheel :websocket-host]) "localhost")]
+          (if-not (= :js-client-host host)
+            (-> build
+              (update-in [:figwheel] dissoc :websocket-host)
+              (assoc-in [:figwheel :websocket-url]
+                        (str "ws://" host ":" (:server-port figwheel-server) "/figwheel-ws")))
+            build))
         build))
     build))
 

--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -235,11 +235,12 @@
   (if (figwheel-build? build)
     (let [build (prep-build-for-figwheel-client build)]
       (if-not (get-in build [:figwheel :websocket-url]) ;; prefer 
-        (let [host (or (get-in build [:figwheel :websocket-host]) "localhost")]
+        (if-let [host (get-in build [:figwheel :websocket-host])]
           (-> build
             (update-in [:figwheel] dissoc :websocket-host)
             (assoc-in [:figwheel :websocket-url]
-                      (str "ws://" host ":" (:server-port figwheel-server) "/figwheel-ws"))))        
+                      (str "ws://" host ":" (:server-port figwheel-server) "/figwheel-ws")))
+          build)
         build))
     build))
 

--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -241,7 +241,7 @@
               (update-in [:figwheel] dissoc :websocket-host)
               (assoc-in [:figwheel :websocket-url]
                         (str "ws://" host ":" (:server-port figwheel-server) "/figwheel-ws")))
-            build))
+            (update-in build [:figwheel] dissoc :websocket-host)))
         build))
     build))
 


### PR DESCRIPTION
Given that `:websocket-host` defaults to `"localhost"`, when connected to a running figwheel instance from an external device (e.g. a tablet or another PC), the `:websocket-url` is configured to `"ws://localhost:3449/figwheel-ws"`.  The only way to get this to work is explicitly set the `:websocket-host` at a minimum.  If you're like me, you probably change wi-fi networks frequently, and therefore get assigned IP addresses frequently.  

Looking at source in the support subproject, `figwheel.client/config-defaults` properly handles creating the websocket url based on the javascript `location.host`.  So, automatically, it will connect to localhost if I've loaded the app via `http://localhost:3449`, or to my ip, if I've gone to `http://<my ip>:3449`.

Long story short, we don't need to default this when generating the `figwheel/connect.cljs`