### PR TITLE
introduce :eval-fn client option

### DIFF
--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -108,7 +108,7 @@
               (string/split-lines stack-str)))
 
 (let [base-path (utils/base-url-path)]
-  (defn eval-javascript** [code result-handler]
+  (defn eval-javascript** [code opts result-handler]
     (try
       (binding [*print-fn* (fn [& args]
                              (-> args
@@ -117,7 +117,7 @@
                 *print-newline* false]
         (result-handler
          {:status :success,
-          :value (str (js* "eval(~{code})"))}))
+          :value (str (utils/eval-helper code opts))}))
       (catch js/Error e
         (result-handler
          {:status :exception
@@ -141,7 +141,7 @@
   (fn [[{:keys [msg-name] :as msg} & _]]
     (when (= :repl-eval msg-name)
       (ensure-cljs-user)
-      (eval-javascript** (:code msg)
+      (eval-javascript** (:code msg) opts
        (fn [res]
          (socket/send! {:figwheel-event "callback"
                         :callback-name (:callback-name  msg)
@@ -271,6 +271,8 @@
    :heads-up-display true
 
    :load-unchanged-files true
+
+   :eval-fn false
    })
 
 (defn handle-deprecated-jsload-callback [config]

--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -173,12 +173,12 @@
 (defn add-request-urls [opts files]
   (map (partial add-request-url opts) files))
 
-(defn eval-body [{:keys [eval-body file]}]
+(defn eval-body [{:keys [eval-body file]} opts]
   (when (and eval-body (string? eval-body))
     (let [code eval-body]
       (try
         (utils/debug-prn (str "Evaling file " file))
-        (js* "eval(~{code})")
+        (utils/eval-helper code opts)
         (catch :default e
           (utils/log :error (str "Unable to evaluate " file)))))))
 
@@ -194,7 +194,7 @@
     (let [eval-bodies (filter #(:eval-body %) files)]
       (when (not-empty eval-bodies)
         (doseq [eval-body-file eval-bodies]
-          (eval-body eval-body-file))))
+          (eval-body eval-body-file opts))))
     
     (let [all-files (filter #(and (:namespace %)
                                   (not (:eval-body %)))

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -41,3 +41,8 @@
             :error #(.error js/console %)
             #(.log js/console %))]
      (f arg))))
+
+(defn eval-helper [code {:keys [eval-fn] :as opts}]
+  (if eval-fn
+    (eval-fn code opts)
+    (js* "eval(~{code})")))


### PR DESCRIPTION
I needed this to customize how javascript is eval'd in the context of Atom's package.
I had to implement loophole's approach and use vm.runInThisContext(...) instead of eval(...)

https://github.com/atom/loophole