### PR TITLE
Revert "WIP: on-* hooks can be either a string or a vector of string"

### DIFF
--- a/sidecar/src/figwheel_sidecar/auto_builder.clj
+++ b/sidecar/src/figwheel_sidecar/auto_builder.clj
@@ -129,7 +129,7 @@
 
 (defn extract-connection-script-figwheel-start [{:keys [figwheel]}]
   (let [func-map (select-keys figwheel figwheel-client-hook-keys)
-        func-map (into {} (map (fn [[k v]] [k (map #(try-jsreload-hook k %) (if (vector? v) v [v]))]) func-map))
+        func-map (into {} (map (fn [[k v]] [k (try-jsreload-hook k v)]) func-map))
         res (merge figwheel func-map)]
     (list 'figwheel.client/start res)))
 
@@ -140,8 +140,6 @@
 (comment
 
   (extract-connection-script-required-ns {:figwheel {:on-jsload "blah.blah/on-jsload"}})
-
-  (extract-connection-script-required-ns {:figwheel {:on-jsload ["blah.blah/on-jsload"]}})
 
   (extract-connection-script-required-ns {:figwheel {}})
 

--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -224,7 +224,7 @@
 ;; you can listen to this event easily like so:
 ;; document.body.addEventListener("figwheel.js-reload", function (e) { console.log(e.detail);} );
 
-(def default-on-jsload [identity])
+(def default-on-jsload identity)
 
 (defn default-on-compile-fail [{:keys [formatted-exception exception-data cause] :as ed}]
   (utils/log :debug "Figwheel: Compile Exception")
@@ -282,12 +282,6 @@
         (dissoc :jsload-callback))
     config))
 
-(defn wrap-on-jsload [config]
- (let [callback (:on-jsload config)]
-   (if (or (vector? callback) (list? callback))
-     config
-     (assoc config :on-jsload [callback]))))
-
 (defn base-plugins [system-options]
   (let [base {:enforce-project-plugin enforce-project-plugin
               :file-reloader-plugin     file-reloader-plugin
@@ -324,8 +318,7 @@
                  merge-plugins (:merge-plugins opts) ;; merges plugins
                  system-options (-> config-defaults
                                   (merge (dissoc opts :plugins :merge-plugins))
-                                  (handle-deprecated-jsload-callback)
-                                  (wrap-on-jsload))
+                                  (handle-deprecated-jsload-callback))
                  plugins  (if plugins'
                             plugins'
                             (merge (base-plugins system-options) merge-plugins))]

--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -215,7 +215,7 @@
                                     file)) res)))
         (js/setTimeout #(do
                           (on-jsload-custom-event res)
-                          (map #(apply % [res]) on-jsload)) 10))
+                          (apply on-jsload [res])) 10))
       (when (not-empty files-not-loaded)
         (utils/log :debug "Figwheel: NOT loading these files ")
         (let [{:keys [figwheel-no-load file-changed-on-disk not-required]}


### PR DESCRIPTION
Reverts bhauman/lein-figwheel#191

This is failing for the basic case of providing multiple hooks in the bulid :figwheel config in the project.clj