### PR TITLE
Fixed string/replace in base-url-path

### DIFF
--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -12,7 +12,7 @@
 
 (defn host-env? [] (if (node-env?) :node :html))
 
-(defn base-url-path [] (string/replace goog/basePath #"(.*)goog/" #(str %2)))
+(defn base-url-path [] (string/replace goog/basePath #"(.*)goog/" "$1"))
 
 (defn dispatch-custom-event [event-name data]
   (when (and (html-env?) (aget js/window "CustomEvent"))


### PR DESCRIPTION
Semantic of `string/replace` [has changed](http://dev.clojure.org/jira/browse/CLJS-1304) in 1.7.122. Thus it’s better to avoid `string/replace` calls with fn as third argument if version of CLJS is not known in advance.

This path fixes broken updates of file notification changes