### PR TITLE
:ring-handler to remember var, not value

### DIFF
--- a/sidecar/src/figwheel_sidecar/core.clj
+++ b/sidecar/src/figwheel_sidecar/core.clj
@@ -453,7 +453,7 @@
   (when ring-handler (require (symbol (namespace (symbol ring-handler)))))
   (assoc opts :ring-handler
          (when ring-handler
-           (eval (symbol ring-handler)))))
+           (resolve (symbol ring-handler)))))
 
 (defn start-server
   ([] (start-server {}))


### PR DESCRIPTION
Right now `:ring-handler` binds to the _value_ of the handler. It means live-reloading code does not affect server behaviour. Standard practice in developing ring apps is to bind to _var_ instead: this way changes in ring handler code will be seen immediately by the server.