### PR TITLE
Allow to use in application system

### DIFF
--- a/sidecar/src/figwheel_sidecar/build_hooks/clj_reloading.clj
+++ b/sidecar/src/figwheel_sidecar/build_hooks/clj_reloading.clj
@@ -98,8 +98,8 @@
     false
     config))
 
-(defn build-hook [build-fn]
-  (fn [{:keys [figwheel-server build-config changed-files] :as build-state}]
+(defn build-hook [figwheel-server build-fn]
+  (fn [{:keys [build-config changed-files] :as build-state}]
     (let [reload-config (default-config figwheel-server)]
       (if-let [changed-clj-files (and
                                   reload-config

--- a/sidecar/src/figwheel_sidecar/build_hooks/injection.clj
+++ b/sidecar/src/figwheel_sidecar/build_hooks/injection.clj
@@ -134,9 +134,9 @@
   (when (config/figwheel-build? build)
     (require-connection-script-js build)))
 
-(defn build-hook [build-fn]
-  (fn [{:keys [figwheel-server build-config] :as build-state}]
+(defn build-hook [figwheel-server build-fn]
+  (fn [{:keys [build-config] :as build-state}]
     (build-fn
      (assoc build-state
             :build-config (add-connect-script! figwheel-server build-config)))
-    (append-connection-init! build-config)))
+    (append-connection-init! (assoc build-config :figwheel-server figwheel-server))))

--- a/sidecar/src/figwheel_sidecar/build_hooks/javascript_reloading.clj
+++ b/sidecar/src/figwheel_sidecar/build_hooks/javascript_reloading.clj
@@ -49,8 +49,8 @@
   (when-not (empty? changed-js)
     (make-copies (get-js-copies state changed-js))))
 
-(defn build-hook [build-fn]
-  (fn [{:keys [figwheel-server build-config changed-files] :as build-state}]
+(defn build-hook [figwheel-server build-fn]
+  (fn [{:keys [build-config changed-files] :as build-state}]
     (if-let [changed-js-files (filter #(.endsWith % ".js") changed-files)]
       (let [build-options (or (:build-options build-config) (:compiler build-config))
             additional-changed-ns   ;; add in js namespaces

--- a/sidecar/src/figwheel_sidecar/channel_server.clj
+++ b/sidecar/src/figwheel_sidecar/channel_server.clj
@@ -1,4 +1,7 @@
-(ns figwheel-sidecar.channel-server)
+(ns figwheel-sidecar.channel-server
+  (:require [cljs.compiler :as comp]
+            [cljs.analyzer :as ana]
+            [clojure.edn :as edn]))
 
 (defprotocol ChannelServer
   (-send-message [this channel-id msg-data callback])
@@ -15,6 +18,18 @@
    (eval-js figwheel-server channel-id code nil))
   ([figwheel-server channel-id code callback]
    (-send-message figwheel-server channel-id {:msg-name :repl-eval :code code} callback)))
+
+(defn eval-cljs
+  ([figwheel-server channel-id code]
+   (eval-cljs figwheel-server channel-id code nil))
+  ([figwheel-server channel-id code callback]
+   (let [js-code (->> code
+                   edn/read-string
+                   (ana/analyze (ana/empty-env))
+                   ana/no-warn
+                   comp/emit
+                   with-out-str)]
+     (eval-js figwheel-server channel-id js-code))))
 
 (defn connection-data [figwheel-server]
   (-connection-data figwheel-server))

--- a/sidecar/src/figwheel_sidecar/channel_server.clj
+++ b/sidecar/src/figwheel_sidecar/channel_server.clj
@@ -1,0 +1,16 @@
+(ns figwheel-sidecar.channel-server)
+
+(defprotocol ChannelServer
+  (-send-message [this channel-id msg-data callback])
+  (-connection-data [this]))
+
+(defn send-message [figwheel-server channel-id msg-data]
+  (-send-message figwheel-server channel-id msg-data nil))
+
+(defn send-message-with-callback [figwheel-server channel-id msg-data callback]
+  (-send-message figwheel-server channel-id msg-data callback))
+
+(defn connection-data [figwheel-server]
+  (-connection-data figwheel-server))
+
+

--- a/sidecar/src/figwheel_sidecar/channel_server.clj
+++ b/sidecar/src/figwheel_sidecar/channel_server.clj
@@ -14,7 +14,7 @@
   ([figwheel-server channel-id code]
    (eval-js figwheel-server channel-id code nil))
   ([figwheel-server channel-id code callback]
-   (send-message-with-callback figwheel-server channel-id {:msg-name :repl-eval :code code} callback)))
+   (-send-message figwheel-server channel-id {:msg-name :repl-eval :code code} callback)))
 
 (defn connection-data [figwheel-server]
   (-connection-data figwheel-server))

--- a/sidecar/src/figwheel_sidecar/channel_server.clj
+++ b/sidecar/src/figwheel_sidecar/channel_server.clj
@@ -10,6 +10,12 @@
 (defn send-message-with-callback [figwheel-server channel-id msg-data callback]
   (-send-message figwheel-server channel-id msg-data callback))
 
+(defn eval-js
+  ([figwheel-server channel-id code]
+   (eval-js figwheel-server channel-id code nil))
+  ([figwheel-server channel-id code callback]
+   (send-message-with-callback figwheel-server channel-id {:msg-name :repl-eval :code code} callback)))
+
 (defn connection-data [figwheel-server]
   (-connection-data figwheel-server))
 

--- a/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
+++ b/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
@@ -91,7 +91,7 @@
               ;;                     cljs-build-fn)
 
                                         ;(-> cljs-build injection/build-hook figwheel-start-and-end-messages)
-              components (-> this (dissoc :build-config) vals)
+              components (->> this vals (filter #(satisfies? component/Lifecycle %)))
               hooks (->> components (mapv :cljsbuild/hook) (filter some?))
               once-hooks (->> components (mapv :cljsbuild/once-hook) (filter some?))
 

--- a/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
+++ b/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
@@ -112,6 +112,7 @@
                 injection/build-hook
                 figwheel-start-and-end-messages)
             cljs-build-fn) this)
+
           (assoc this
                  ;; for simple introspection
                  :cljs-autobuild true

--- a/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
+++ b/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
@@ -132,7 +132,7 @@
       (println "Figwheel: Stopped watching build -" (:id build-config))
       (flush)
       (watching/stop! (:file-watcher this)))
-    (dissoc this :file-watcher)))
+    (assoc this :file-watcher nil)))
 
 (defn cljs-autobuild
   "  Creates a ClojureScript autobuilding component that watches

--- a/sidecar/src/figwheel_sidecar/components/css_watcher.clj
+++ b/sidecar/src/figwheel_sidecar/components/css_watcher.clj
@@ -1,5 +1,7 @@
 (ns figwheel-sidecar.components.css-watcher
   (:require
+   [figwheel-sidecar.channel-server :as server]
+   [figwheel-sidecar.components.figwheel-server :as fig]
    [figwheel-sidecar.components.file-system-watcher :as fsw]
    [figwheel-sidecar.utils :as utils]))
 
@@ -8,7 +10,7 @@
     :type :css } )
 
 (defn send-css-files [figwheel-server files]
-  (fig/send-message figwheel-server
+  (server/send-message figwheel-server
                     ::fig/broadcast
                     { :msg-name :css-files-changed
                       :files files}))

--- a/sidecar/src/figwheel_sidecar/components/css_watcher.clj
+++ b/sidecar/src/figwheel_sidecar/components/css_watcher.clj
@@ -1,8 +1,7 @@
 (ns figwheel-sidecar.components.css-watcher
   (:require
    [figwheel-sidecar.components.file-system-watcher :as fsw]
-   [figwheel-sidecar.utils :as utils]
-   [figwheel-sidecar.components.figwheel-server :as fig]))
+   [figwheel-sidecar.utils :as utils]))
 
 (defn make-css-file [path]
   { :file (utils/remove-root-path path)

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -121,7 +121,7 @@
                         config))))
     (catch java.net.BindException e
       (println "Port" server-port "is already being used. Are you running another Figwheel instance? If you want to run two Figwheel instances add a new :server-port (i.e. :server-port 3450) to Figwheel's config options in your project.clj")
-      (System/exit 0))))
+      #_(System/exit 0))))
 
 (defn append-msg [q msg] (conj (take 30 q) msg))
 
@@ -197,7 +197,7 @@
 
 ;; external api
 
-(defrecord FigwheelServer []
+(defrecord FigwheelServer [handler]
   component/Lifecycle
   (start [this]
     (if-not (:http-server this)
@@ -214,6 +214,9 @@
     (->> (prep-message this channel-id msg-data callback)
          (swap! file-change-atom append-msg)))
   (-connection-data [{:keys [connection-count]}] @connection-count))
+
+(defn new-figwheel-server [& opts]
+  (map->FigwheelServer (or opts {})))
 
 (defn send-message [figwheel-server channel-id msg-data]
   (-send-message figwheel-server channel-id msg-data nil))

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -253,10 +253,6 @@
          (swap! file-change-atom append-msg)))
   (-connection-data [{:keys [connection-count]}] @connection-count))
 
-(defn new-figwheel-server [& opts]
-  (map->FigwheelServer (or opts {})))
-
-
 ;; setup server for overall system 
 
 (defn ensure-array-map [all-builds]

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -127,12 +127,16 @@
       (if (ifn? on-connect)
         (on-connect server-state channel)))))
 
-(defn- run-http-server [{:keys [server-port server-ip] :as server-state} handler]
+(defn- run-http-server [{:keys [server-port server-ip resolved-ring-handler] :as server-state} handler]
   (try
-    (run-server handler (let [config {:port server-port :worker-name-prefix "figwh-httpkit-"}]
-                          (if server-ip
-                            (assoc config :ip server-ip)
-                            config)))
+    (let [routes-with-static (routes handler
+                                     (or resolved-ring-handler (fn [r] false))
+                                     (route/not-found "<h1>Page not found</h1>"))
+          config {:port server-port :worker-name-prefix "figwh-httpkit-"}]
+      (run-server routes-with-static
+                  (if server-ip
+                    (assoc config :ip server-ip)
+                    config)))
     (catch java.net.BindException e
       (println "Port" server-port "is already being used. Are you running another Figwheel instance? If you want to run two Figwheel instances add a new :server-port (i.e. :server-port 3450) to Figwheel's config options in your project.clj")
       (System/exit 0))))

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -238,8 +238,8 @@
             cljsbuild-hook (figwheel-build state)
             cljsbuild-once-hook (partial injection/build-hook state)]
         (map->FigwheelServer (assoc state
-                                    :cljsbuild/hook cljsbuild-hook
-                                    :cljsbuild/once-hook cljsbuild-once-hook)))
+                                    :cljsbuild/on-build cljsbuild-hook
+                                    :cljsbuild/on-first-build cljsbuild-once-hook)))
       this))
   (stop [this]
     (when (:http-server this)

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -143,9 +143,7 @@
        (GET "/figwheel-ws/:desired-build-id" {params :params} (reload-handler server-state))
        (GET "/figwheel-ws" {params :params} (reload-handler server-state))       
        (route/resources "/" {:root http-server-root})
-       ;; (or resolved-ring-handler (fn [r] false))
-       (GET "/" [] (resource-response "index.html" {:root http-server-root}))
-       (route/not-found "<h1>Page not found</h1>"))
+       (GET "/" [] (resource-response "index.html" {:root http-server-root})))
       ;; adding cors to support @font-face which has a strange cors error
       ;; super promiscuous please don't uses figwheel as a production server :)
       (cors/wrap-cors

--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -6,7 +6,15 @@
    [clojure.string :as string]
    [clojure.java.io :as io]
    [clojure.walk :as walk]
-   [cljs.env]))
+   [cljs.env])
+  (:import [com.stuartsierra.component SystemMap]))
+
+;; make inspecting more friendly to copy/paste/read-string
+(defrecord CljsEnv [])
+(defmethod print-method ::cljs-env [o ^java.io.Writer w]
+  (.write w "#figwheel_sidecar.config.CljsEnv{}"))
+(defmethod print-method SystemMap [o ^java.io.Writer w]
+  (.write w "#com.stuartsierra.component.SystemMap{}"))
 
 (defn get-build-options [build]
    (or (:build-options build) (:compiler build) {}))
@@ -279,9 +287,8 @@
 (defn add-compiler-env [{:keys [build-options] :as build}]
   (assoc build
          :compiler-env
-         #_(cljs.env/default-compiler-env build-options)
          (atom (swap! (cljs.env/default-compiler-env build-options)
-                      #(with-meta % {:type :cljs/env})))))
+                      #(with-meta % {:type ::cljs-env})))))
 
 (defn get-project-builds []
   (into (array-map)

--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -264,17 +264,24 @@
 
 (defrecord CljsEnv [])
 (defmethod print-method :cljs/env [o ^java.io.Writer w]
-  (.write w "#figwheel-sidecar.config.CljsEnv{}"))
+  (.write w "#figwheel_sidecar.config.CljsEnv{}"))
 
 (require 'com.stuartsierra.component)
 (defmethod print-method com.stuartsierra.component.SystemMap [o ^java.io.Writer w]
   (.write w "#com.stuartsierra.component.SystemMap{}"))
 
+(require 'aprint.core)
+(defmethod print-method clojure.lang.ExceptionInfo [o ^java.io.Writer w]
+  (let [msg (-> o .getMessage)
+        data (-> o .getData aprint.core/aprint with-out-str)]
+    (.write w (str msg "\n" data))))
+
 (defn add-compiler-env [{:keys [build-options] :as build}]
   (assoc build
          :compiler-env
-         (swap! (cljs.env/default-compiler-env build-options)
-                #(with-meta % {:type :cljs/env}))))
+         #_(cljs.env/default-compiler-env build-options)
+         (atom (swap! (cljs.env/default-compiler-env build-options)
+                      #(with-meta % {:type :cljs/env})))))
 
 (defn get-project-builds []
   (into (array-map)

--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -262,10 +262,19 @@
 (defn fetch-config []
   (prep-config (config)))
 
+(defrecord CljsEnv [])
+(defmethod print-method :cljs/env [o ^java.io.Writer w]
+  (.write w "#figwheel-sidecar.config.CljsEnv{}"))
+
+(require 'com.stuartsierra.component)
+(defmethod print-method com.stuartsierra.component.SystemMap [o ^java.io.Writer w]
+  (.write w "#com.stuartsierra.component.SystemMap{}"))
+
 (defn add-compiler-env [{:keys [build-options] :as build}]
   (assoc build
          :compiler-env
-         (cljs.env/default-compiler-env build-options)))
+         (swap! (cljs.env/default-compiler-env build-options)
+                #(with-meta % {:type :cljs/env}))))
 
 (defn get-project-builds []
   (into (array-map)

--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -9,7 +9,7 @@
    [clojure.core.async :refer [chan <!! <! put! alts!! timeout close! go go-loop]]
 
    [clojure.tools.nrepl.middleware.interruptible-eval :as nrepl-eval]
-   [figwheel-sidecar.components.figwheel-server :as server]
+   [figwheel-sidecar.channel-server :as server]
    
    [figwheel-sidecar.config :as config]))
 

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -21,8 +21,6 @@
 
 (def fetch-config config/fetch-config)
 
-(def figwheel-server figwheel/figwheel-server)
-(def figwheel-build figwheel/figwheel-build)
 (def cljs-autobuild autobuild/cljs-autobuild)
 (def css-watcher css-watch/css-watcher)
 (def nrep-server-component nrepl-comp/nrepl-server-component)
@@ -73,7 +71,7 @@
 
 (defn create-figwheel-system [{:keys [figwheel-options all-builds build-ids] :as options}]
   (-> (component/system-map
-       :figwheel-server (server/figwheel-server options))
+       :figwheel-server (figwheel/figwheel-server options))
       (add-initial-builds (map name build-ids))
       #_(add-css-watcher  (:css-dirs figwheel-options))
       #_(add-nrepl-server (select-keys figwheel-options [:nrepl-port
@@ -209,7 +207,7 @@
       ;; we are allwing build to be overridden at the system level
       ((or
         (:cljs-build-fn system)
-        (figwheel-build figwheel-server))
+        (figwheel/figwheel-build figwheel-server))
        (assoc system :build-config build-config)))
     system))
 
@@ -334,7 +332,7 @@
     (println "Prompt will show when Figwheel connects to your application")
     (frepl/repl
      build
-     figwheel-server
+     figwheel/figwheel-server
      (update-in repl-options [:special-fns]
                 merge
                 (build-figwheel-special-fns system)))))

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -73,8 +73,8 @@
   (-> (component/system-map
        :figwheel-server (figwheel/figwheel-server options))
       (add-initial-builds (map name build-ids))
-      #_(add-css-watcher  (:css-dirs figwheel-options))
-      #_(add-nrepl-server (select-keys figwheel-options [:nrepl-port
+      (add-css-watcher  (:css-dirs figwheel-options))
+      (add-nrepl-server (select-keys figwheel-options [:nrepl-port
                                                        :nrepl-host
                                                        :nrepl-middleware]))))
 
@@ -332,7 +332,7 @@
     (println "Prompt will show when Figwheel connects to your application")
     (frepl/repl
      build
-     figwheel/figwheel-server
+     figwheel-server
      (update-in repl-options [:special-fns]
                 merge
                 (build-figwheel-special-fns system)))))

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -3,11 +3,12 @@
    [figwheel-sidecar.utils :as utils]   
    [figwheel-sidecar.config :as config]
    [figwheel-sidecar.repl :refer [repl-println] :as frepl]   
+   [figwheel-sidecar.channel-server :as server]
 
    [figwheel-sidecar.components.nrepl-server   :as nrepl-comp]
    [figwheel-sidecar.components.css-watcher     :as css-watch]
    [figwheel-sidecar.components.cljs-autobuild   :as autobuild]
-   [figwheel-sidecar.components.figwheel-server :as server]      
+   [figwheel-sidecar.components.figwheel-server :as figwheel]
    
    [com.stuartsierra.component :as component]
 
@@ -20,7 +21,8 @@
 
 (def fetch-config config/fetch-config)
 
-(def figwheel-server server/figwheel-server)
+(def figwheel-server figwheel/figwheel-server)
+(def figwheel-build figwheel/figwheel-build)
 (def cljs-autobuild autobuild/cljs-autobuild)
 (def css-watcher css-watch/css-watcher)
 (def nrep-server-component nrepl-comp/nrepl-server-component)
@@ -198,7 +200,7 @@
      #(reduce clean-build % ids))))
 
 ;; doesn't change the system
-(defn build-once* [system id]
+(defn build-once* [{:keys [figwheel-server] :as system} id]
   (when-let [build-config
              (id->build-config system (name id))
              #_(get (:builds system) (name id))]
@@ -207,8 +209,7 @@
       ;; we are allwing build to be overridden at the system level
       ((or
         (:cljs-build-fn system)
-        (get-in system [:figwheel-server :cljs-build-fn])
-        autobuild/figwheel-build)
+        (figwheel-build figwheel-server))
        (assoc system :build-config build-config)))
     system))
 

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -73,8 +73,8 @@
   (-> (component/system-map
        :figwheel-server (server/figwheel-server options))
       (add-initial-builds (map name build-ids))
-      (add-css-watcher  (:css-dirs figwheel-options))
-      (add-nrepl-server (select-keys figwheel-options [:nrepl-port
+      #_(add-css-watcher  (:css-dirs figwheel-options))
+      #_(add-nrepl-server (select-keys figwheel-options [:nrepl-port
                                                        :nrepl-host
                                                        :nrepl-middleware]))))
 


### PR DESCRIPTION
This PR shouldn’t change anything in current behaviour, it only add new ones: the main idea is what I told you in #clojurescript channel on slack: allow to use separate components in application system (see example https://github.com/razum2um/figwheel-example/blob/master/src/clj/figwheel_example/core.clj#L40L52). in short it does:

- [x] make components repl-readable => easy debugable (see screenshot of example app)
- [x] decompose cljsbuild from figwheel by passing only hooks around, start to decompose figwheel from http-server
- [x] allow to define custom hooks on cljsbuild (on initilal build & on furher ones)
- [x] expose clear interface to `eval-js` & `eval-cljs` in browser within application system
- [x] killer feature (imho): be able to reload custom route handlers automatically (even without system reset) see https://github.com/razum2um/figwheel-example/blob/master/src/clj/figwheel_example/core.clj#L30L32
- [x] killer feature (imho): allow to define a state-atom in cljc namespace which acts as a data-bridge between server and browser with a small snippet (in app example). it automagically get updates in browser, moreover this state will be loaded on browser refresh too (with some caveats) see watch function https://github.com/razum2um/figwheel-example/blob/master/src/clj/figwheel_example/core.clj#L12L22 and its usage https://github.com/razum2um/figwheel-example/blob/master/src/clj/figwheel_example/core.clj#L46
