### PR TITLE
Set Piggieback REPL output directory (fixes #268)

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -126,13 +126,14 @@
   (try
     (require 'cemerick.piggieback)
     (let [cljs-repl (resolve 'cemerick.piggieback/cljs-repl)
-          special-fns (or (:special-fns opts) cljs.repl/default-special-fns)]
+          special-fns (or (:special-fns opts) cljs.repl/default-special-fns)
+          output-dir (or (:output-dir opts) "out")]
       (try
         ;; Piggieback version 0.2+
-        (cljs-repl figwheel-env :special-fns special-fns)
+        (cljs-repl figwheel-env :special-fns special-fns :output-dir output-dir)
         (catch Exception e
           ;; Piggieback version 0.1.5
-          (cljs-repl :repl-env figwheel-env :special-fns special-fns))))
+          (cljs-repl :repl-env figwheel-env :special-fns special-fns :output-dir output-dir))))
     (catch Exception e
       (println "INFO: nREPL connection found but unable to load piggieback. Starting default REPL")
       (start-cljs-repl :default figwheel-env opts))))


### PR DESCRIPTION
This commit should fix the issue with Piggieback using the wrong output directory for compiling ClojureScript.