### PR TITLE
Update http-kit

### DIFF
--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -12,7 +12,7 @@
     :exclusions [org.apache.ant/ant]]
    [org.clojure/core.async "0.2.374"]   
    [com.stuartsierra/component "0.3.0"]
-   [http-kit "2.1.18"]
+   [http-kit "2.1.19"]
    [ring-cors "0.1.7"]
    [compojure "1.4.0"]
    [clj-stacktrace "0.2.8"]


### PR DESCRIPTION
This will suppress the exception that occurs when you stop figwheel.

HTTP Kit's README and project.clj say its latest version is 2.1.18 but actual one is 2.1.19.
See: https://github.com/http-kit/http-kit/commit/603955e74781dffdd67b62d4e6e30c491bacb671
