### PR TITLE
Print exception when requiring handler fails

### DIFF
--- a/sidecar/src/figwheel_sidecar/utils.clj
+++ b/sidecar/src/figwheel_sidecar/utils.clj
@@ -24,7 +24,13 @@
       (when (.exists file) (.delete file)))))
 
 (defn require? [symbol]
-  (try (require symbol) true (catch Exception e false)))
+  (try
+    (require symbol)
+    true
+    (catch Exception e
+      (println (.getMessage e))
+      (.printStackTrace e)
+      false)))
 
 (defn require-resolve-handler [handler]
   (when handler


### PR DESCRIPTION
In some cases, the handler can be loaded without problems with `lein ring server` while failing with `lein figwheel`. For example, in my case: `ring-core` is imported instead of the whole `ring` but some libraries imported by the handler are loaded via `lein-ring`. This is a mistake from my part, but the fact that `figwheel-sidecar` is completely silent about this doesn't help at all. I think it would be really useful to print the exception if it does indeed happen.