### PR TITLE
Figwheel + Devtools

### DIFF
--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -12,6 +12,7 @@
     :exclusions [org.apache.ant/ant]]
    [org.clojure/core.async "0.2.374"
     :exclusions [org.clojure/tools.reader]]
+   [com.cognitect/transit-clj "0.8.285"]
    [com.stuartsierra/component "0.3.0"]
    [http-kit "2.1.19"]
    [ring-cors "0.1.7"

--- a/sidecar/src/figwheel_sidecar/protocols.clj
+++ b/sidecar/src/figwheel_sidecar/protocols.clj
@@ -1,0 +1,5 @@
+(ns figwheel-sidecar.protocols)
+
+(defprotocol ChannelServer
+  (-send-message [this channel-id msg-data callback])
+  (-connection-data [this]))

--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -2,15 +2,13 @@
   (:require
    [cljs.repl]
    [cljs.stacktrace]
-   [cljs.env :as env]
 
-   [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.core.async :refer [chan <!! <! put! alts!! timeout close! go go-loop]]
 
    [clojure.tools.nrepl.middleware.interruptible-eval :as nrepl-eval]
    [figwheel-sidecar.components.figwheel-server :as server]
-   
+   [figwheel-sidecar.repl.driver :as driver]
    [figwheel-sidecar.config :as config]))
 
 ;; slow but works
@@ -161,8 +159,10 @@
          repl-opts (assoc opts :compiler-env (:compiler-env build))
          protocol (if (in-nrepl-env?)
                     :nrepl
-                    :default)]
-     (start-cljs-repl protocol figwheel-repl-env repl-opts))))
+                    :default)
+         start-fn (fn [updated-repl-opts]
+                    (start-cljs-repl protocol figwheel-repl-env updated-repl-opts))]
+     (driver/start-repl-with-driver build figwheel-server repl-opts start-fn))))
 
 ;; deprecated 
 (defn get-project-cljs-builds []

--- a/sidecar/src/figwheel_sidecar/repl/controller.clj
+++ b/sidecar/src/figwheel_sidecar/repl/controller.clj
@@ -1,0 +1,21 @@
+(ns figwheel-sidecar.repl.controller
+  (:require
+    [figwheel-sidecar.repl.registry :as registry]
+    [figwheel-sidecar.repl.driver :as driver]))
+
+(defn eval-command-in-current-repl! [msg]
+  (let [driver (registry/get-last-driver)
+        {:keys [code input request-id]} msg]
+    (driver/eval-external-command! driver request-id code input)))
+
+(defn announce-ns-in-current-repl! [_msg]
+  (let [driver (registry/get-last-driver)]
+    (driver/announce-ns driver)))
+
+; -- main handler -----------------------------------------------------------------------------------------------------------
+
+(defn handle-msg [_server-state msg]
+  (case (:command msg)
+    "eval" (eval-command-in-current-repl! msg)
+    "request-ns" (announce-ns-in-current-repl! msg)
+    (println "Received unknown repl-driver message:" msg)))

--- a/sidecar/src/figwheel_sidecar/repl/driver.clj
+++ b/sidecar/src/figwheel_sidecar/repl/driver.clj
@@ -1,0 +1,223 @@
+(ns figwheel-sidecar.repl.driver
+  (:require
+    [clojure.core.async :refer [chan <!! <! >!! put! alts!! timeout close! go go-loop]]
+    [cljs.repl :as cljs-repl]
+    [clojure.tools.reader :as reader]
+    [clojure.tools.reader.reader-types :as reader-types]
+    [figwheel-sidecar.repl.sniffer :as sniffer]
+    [figwheel-sidecar.repl.messaging :as messaging]
+    [cljs.analyzer :as ana]
+    [figwheel-sidecar.repl.registry :as registry]))
+
+; -- driver construction ----------------------------------------------------------------------------------------------------
+
+(defn make-driver [base]
+  (merge base {:commands-channel                     (chan)                                                                   ; channel for REPL commands (command-records) from *in* and also network
+               :current-job                          (volatile! nil)                                                          ; command-record currently being processed {:request-id :kind :command}
+               :recording?                           (volatile! false)                                                        ; recording of printing into *out* and *err*
+               :active-repl-opts                     (volatile! nil)                                                          ; cached repl opts
+               :suppress-print-recording-until-flush (volatile! false)}))                                                     ; temporary suppression of recording
+
+; -- announcements ----------------------------------------------------------------------------------------------------------
+
+(defn announce-job-start [driver job]
+  (let [{:keys [request-id]} job]
+    (messaging/announce-job-start (:server driver) request-id)))
+
+(defn announce-job-end [driver job]
+  (let [{:keys [request-id]} job]
+    (messaging/announce-job-end (:server driver) request-id)))
+
+(defn announce-ns [driver]
+  (messaging/announce-repl-ns (:server driver) (str ana/*cljs-ns*)))
+
+; -- job management ---------------------------------------------------------------------------------------------------------
+
+(defn get-current-job [driver]
+  @(:current-job driver))
+
+(defn start-job! [driver job]
+  {:pre [(not @(:current-job driver))]}
+  (vreset! (:current-job driver) job)
+  (announce-job-start driver job))
+
+(defn stop-job! [driver]
+  {:pre [@(:current-job driver)]}
+  (announce-job-end driver (get-current-job driver))
+  (vreset! (:current-job driver) nil))
+
+; -- print recording --------------------------------------------------------------------------------------------------------
+
+(defn recording? [driver]
+  @(:recording? driver))
+
+(defn start-recording! [driver]
+  (sniffer/clear-content! @(get-in driver [:sniffers :stdout]))
+  (sniffer/clear-content! @(get-in driver [:sniffers :stderr]))
+  (vreset! (:recording? driver) true))
+
+(defn flush-remainder! [driver sniffer-key]
+  (let [sniffer (get-in driver [:sniffers sniffer-key])
+        content (sniffer/extract-content! @sniffer)]
+    (if-not (nil? content)
+      (let [{:keys [request-id]} (get-current-job driver)]
+        (messaging/report-output (:server driver) request-id sniffer-key content)))))
+
+(defn stop-recording! [driver]
+  (when (recording? driver)
+    (flush-remainder! driver :stdout)
+    (flush-remainder! driver :stderr)
+    (vreset! (:recording? driver) false)))
+
+; -- detection of active REPL options ---------------------------------------------------------------------------------------
+
+(defn resolve-repl-opts []
+  (if-let [opts (resolve 'cljs.repl/*repl-opts*)]
+    @opts))
+
+(defn resolve-active-repl-opts-if-needed! [driver]
+  (if-not @(:active-repl-opts driver)
+    (vreset! (:active-repl-opts driver) (resolve-repl-opts))))
+
+(defn get-active-repl-opts! [driver]
+  @(:active-repl-opts driver))
+
+; -- eval externally --------------------------------------------------------------------------------------------------------
+
+; cljs.repl/eval-cljs is private, this is a hack around it
+(defn resolve-eval-cljs []
+  (if-let [eval-cljs-var (resolve 'cljs.repl/eval-cljs)]
+    @eval-cljs-var))
+
+; here we mimic code in cljs.repl/repl*
+(defn current-repl-special-fns [driver]
+  (let [special-fns (:special-fns (get-active-repl-opts! driver))]
+    (merge cljs-repl/default-special-fns special-fns)))
+
+; here we mimic read-eval-print's behaviour in cljs.repl/repl*
+(defn is-special-fn-call-form? [driver form]
+  (let [is-special-fn? (set (keys (current-repl-special-fns driver)))]
+    (and (seq? form) (is-special-fn? (first form)))))
+
+; here we mimic parsing behaviour of cljs.repl/repl-read
+(defn read-input [input]
+  (let [rdr (reader-types/string-push-back-reader input)]
+    (cljs-repl/skip-whitespace rdr)
+    (reader/read {:read-cond :allow :features #{:cljs}} rdr)))
+
+(defn is-special-fn-call? [driver input-text]
+  (is-special-fn-call-form? driver (read-input input-text)))
+
+(defn eval-external-command! [driver request-id code input]
+  ; first, we echo user's input into stdout
+  (println input)
+
+  ; then we try to parse the code and put result on the channel
+  ; in case the code is a special-fn call, we execute user's input
+  ; otherwise we execute code provided from client (which may be a modified version of user's input)
+  (let [effective-code (if (is-special-fn-call? driver input) input code)
+        command (read-input effective-code)
+        command-record {:kind       :external
+                        :command    command
+                        :request-id request-id}]
+    (go
+      (>!! (:commands-channel driver) command-record))))
+
+; -- REPL handler factories -------------------------------------------------------------------------------------------------
+
+(defn multiplexing-reader-factory
+  "This factory creates a new REPL reading function. Normally this function is responsible for waiting for user input on
+  stdin, parsing it and passing a valid form back. REPL system then calls it to parse next form, and so on.
+
+  Our situation is more complicated. We need to provide two sources of inputs, one is traditional stdin as typed by the user.
+  And second source is a sequence of commands incoming over socket from client-side. We want them to be treated as if they
+  were typed into the REPL from standard input.
+
+  We create a channel which will contain all commands. Network handler can put! there a command via exec-external-command!
+  when a new message arives or the original cljs-repl/repl-read can put! there a command when user enters a new form from
+  standard input. We just have to make sure we restart cljs-repl/repl-read if it is not already running."
+  [driver]
+  (let [pending-read? (volatile! false)]
+    (fn [& args]
+      (resolve-active-repl-opts-if-needed! driver)
+
+      (stop-recording! driver)
+      (if (get-current-job driver)
+        (stop-job! driver))
+
+      ; make sure we have a pending read in-flight
+      (when-not @pending-read?
+        (vreset! pending-read? true)
+        (go
+          (let [command (apply cljs-repl/repl-read args)
+                command-record {:kind    :stdin
+                                :command command}]
+            (>!! (:commands-channel driver) command-record)
+            (vreset! pending-read? false))))
+
+      ; wait & serve next input from the channel (can be produced by cljs-repl/repl-read or exec-external-command!)
+      (let [command-record (<!! (:commands-channel driver))]
+        (case (:kind command-record)
+          :stdin (:command command-record)
+          :external (do
+                      (start-job! driver command-record)
+                      (start-recording! driver)
+                      (:command command-record)))))))
+
+(defn custom-eval-factory [driver]
+  (fn [& args]
+    (when-let [eval-cljs (resolve-eval-cljs)]
+      (let [result (apply eval-cljs args)]
+        ; main REPL loop calls eval and then immediatelly prints result value
+        ; we want to prevent that printing to be recorded
+        (if (recording? driver)
+          (vreset! (:suppress-print-recording-until-flush driver) true))
+        result))))
+
+(defn custom-prompt-factory [driver]
+  (fn []
+    (let [stdout-sniffer (get-in driver [:sniffers :stdout])]
+      (announce-ns driver)
+      (cljs-repl/repl-prompt)
+      (sniffer/clear-content! @stdout-sniffer))))
+
+; -- sniffer handlers -------------------------------------------------------------------------------------------------------
+
+(defn flush-handler
+  "This method gets callled every time *out* (or *err*) gets flushed.
+  Our job is to send accumulated (recorded) output to client side."
+  [driver sniffer-key]
+  (let [sniffer (get-in driver [:sniffers sniffer-key])
+        content (sniffer/extract-all-lines-but-last! @sniffer)]
+    (if-not (nil? content)
+      (if (recording? driver)
+        (let [{:keys [request-id]} (get-current-job driver)]
+          (if @(:suppress-print-recording-until-flush driver)
+            (vreset! (:suppress-print-recording-until-flush driver) false)
+            (messaging/report-output (:server driver) request-id sniffer-key content)))))))
+
+
+; -- initialization ---------------------------------------------------------------------------------------------------------
+
+(defn start-repl-with-driver [build figwheel-server opts start-fn]
+  (let [driver (make-driver {:build    build
+                             :server   figwheel-server
+                             :sniffers {:stdout (volatile! nil)
+                                        :stderr (volatile! nil)}})
+        repl-opts (assoc opts
+                    :read (multiplexing-reader-factory driver)
+                    :eval (custom-eval-factory driver)
+                    :prompt (custom-prompt-factory driver)
+                    :bind-err false)]
+    (let [stdout-sniffer (sniffer/make-sniffer *out* (partial flush-handler driver :stdout))
+          stderr-sniffer (sniffer/make-sniffer *out* (partial flush-handler driver :stderr))]                                 ; *out* is here on purpose, see :bind-err and its effect when true (default)
+      (try
+        (vreset! (get-in driver [:sniffers :stdout]) stdout-sniffer)
+        (vreset! (get-in driver [:sniffers :stderr]) stderr-sniffer)
+        (registry/register-driver! :current-repl driver)
+        (binding [*out* stdout-sniffer
+                  *err* stderr-sniffer]
+          (start-fn repl-opts))
+        (finally
+          (sniffer/destroy-sniffer stdout-sniffer)
+          (sniffer/destroy-sniffer stderr-sniffer))))))

--- a/sidecar/src/figwheel_sidecar/repl/messaging.clj
+++ b/sidecar/src/figwheel_sidecar/repl/messaging.clj
@@ -1,0 +1,27 @@
+(ns figwheel-sidecar.repl.messaging
+  (:require
+    [figwheel-sidecar.protocols :as protocols]))
+
+(defn send-message [figwheel-server command & [payload]]
+  (protocols/-send-message figwheel-server
+                           (:build-id figwheel-server)
+                           (merge payload {:msg-name :repl-driver
+                                           :command  command})
+                           nil))
+
+; -- messages ---------------------------------------------------------------------------------------------------------------
+
+(defn announce-job-start [figwheel-server request-id]
+  (send-message figwheel-server :job-start {:request-id request-id}))
+
+(defn announce-job-end [figwheel-server request-id]
+  (send-message figwheel-server :job-end {:request-id request-id}))
+
+(defn announce-repl-ns [figwheel-server ns-as-string]
+  {:pre [(string? ns-as-string)]}
+  (send-message figwheel-server :repl-ns {:ns ns-as-string}))
+
+(defn report-output [figwheel-server request-id kind content]
+  (send-message figwheel-server :output {:request-id request-id
+                                         :kind       kind
+                                         :content    content}))

--- a/sidecar/src/figwheel_sidecar/repl/registry.clj
+++ b/sidecar/src/figwheel_sidecar/repl/registry.clj
@@ -1,0 +1,24 @@
+(ns figwheel-sidecar.repl.registry)
+
+(def drivers (atom {}))
+(def last-registered-driver-id (volatile! nil))
+
+; -- driver management -----------------------------------------------------------------------------------------------------
+
+(defn register-driver! [id driver]
+  {:pre [id]}
+  (swap! drivers assoc id driver)
+  (vreset! last-registered-driver-id id)
+  driver)
+
+(defn unregister-driver! [id]
+  {:pre [id]}
+  (swap! drivers dissoc id))
+
+(defn get-driver [id]
+  {:pre [id]}
+  (id @drivers))
+
+(defn get-last-driver []
+  {:pre [@last-registered-driver-id]}
+  (get-driver @last-registered-driver-id))

--- a/sidecar/src/figwheel_sidecar/repl/sniffer.clj
+++ b/sidecar/src/figwheel_sidecar/repl/sniffer.clj
@@ -1,0 +1,97 @@
+(ns figwheel-sidecar.repl.sniffer
+  (:require [clojure.string :as string])
+  (:import (java.io StringWriter PrintWriter)))
+
+(def sniffer->proxy (atom {}))
+
+(defmacro enter-gate [gate-keeper & body]
+  `(try
+     (vreset! ~gate-keeper (inc (deref ~gate-keeper)))
+     ~@body
+     (finally
+       (vreset! ~gate-keeper (dec (deref ~gate-keeper))))))
+
+(defn open? [gate]
+  (zero? @gate))
+
+; -- constructor ------------------------------------------------------------------------------------------------------------
+
+; see http://docs.oracle.com/javase/7/docs/api/java/io/Writer.html
+(defn make-writer-proxy [writer flush-handler]
+  (let [gate-keeper (volatile! 0)]
+    (proxy [StringWriter] []
+      (write
+        ([x]
+         (if (open? gate-keeper)
+           (.write writer x))
+         (enter-gate gate-keeper
+           (proxy-super write x)))
+        ([x off len]
+         (if (open? gate-keeper)
+           (.write writer x off len))
+         (enter-gate gate-keeper
+           (proxy-super write x off len))))
+      (append
+        ([x]
+         (if (open? gate-keeper)
+           (.append writer x))
+         (enter-gate gate-keeper
+           (proxy-super append x))
+         this)
+        ([x start end]
+         (if (open? gate-keeper)
+           (.append writer x start end))
+         (enter-gate gate-keeper
+           (proxy-super append x start end))
+         this))
+      (close
+        ([]
+         (.close writer)
+         (proxy-super close)))
+      (flush
+        ([]
+         (.flush writer)
+         (proxy-super flush)
+         (flush-handler))))))
+
+; note: some cljs.repl code expects *err* to be PrintWriter instance, not just a Writer instance
+;       e.g. it calls (.printStackTrace e *err*)
+(defn make-sniffer [writer flush-handler]
+  (let [proxy (make-writer-proxy writer flush-handler)
+        sniffer (PrintWriter. proxy true)]
+    (swap! sniffer->proxy assoc sniffer proxy)
+    sniffer))
+
+(defn destroy-sniffer [sniffer]
+  {:pre  [(instance? PrintWriter sniffer)]}
+  (swap! sniffer->proxy dissoc sniffer))
+
+; -- helpers ----------------------------------------------------------------------------------------------------------------
+
+(defn get-writer [sniffer]
+  {:pre  [(instance? PrintWriter sniffer)]
+   :post [(instance? StringWriter %)]}
+  (get @sniffer->proxy sniffer))
+
+(defn clear-content! [sniffer]
+  {:pre  [(instance? PrintWriter sniffer)]}
+  (let [buffer (.getBuffer (get-writer sniffer))]
+    (.setLength buffer 0)))
+
+(defn extract-all-lines-but-last! [sniffer]
+  {:pre  [(instance? PrintWriter sniffer)]}
+  (let [content (.toString (get-writer sniffer))]
+    (if-not (empty? content)
+      (let [lines (string/split content #"\n" -1)                                                                             ; http://stackoverflow.com/a/29614863/84283
+            lines-ready (butlast lines)
+            remainder (last lines)]
+        (clear-content! sniffer)
+        (.append sniffer remainder)
+        (string/join "\n" lines-ready)))))
+
+(defn extract-content! [sniffer]
+  {:pre  [(instance? PrintWriter sniffer)]}
+  (let [content (.toString (get-writer sniffer))]
+    (when-not (empty? content)
+      (clear-content! sniffer)
+      content)))

--- a/sidecar/src/figwheel_sidecar/repl/sniffer.clj
+++ b/sidecar/src/figwheel_sidecar/repl/sniffer.clj
@@ -52,7 +52,8 @@
         ([]
          (.flush writer)
          (proxy-super flush)
-         (flush-handler))))))
+         (if flush-handler
+           (flush-handler)))))))
 
 ; note: some cljs.repl code expects *err* to be PrintWriter instance, not just a Writer instance
 ;       e.g. it calls (.printStackTrace e *err*)
@@ -63,7 +64,7 @@
     sniffer))
 
 (defn destroy-sniffer [sniffer]
-  {:pre  [(instance? PrintWriter sniffer)]}
+  {:pre [(instance? PrintWriter sniffer)]}
   (swap! sniffer->proxy dissoc sniffer))
 
 ; -- helpers ----------------------------------------------------------------------------------------------------------------
@@ -74,12 +75,12 @@
   (get @sniffer->proxy sniffer))
 
 (defn clear-content! [sniffer]
-  {:pre  [(instance? PrintWriter sniffer)]}
+  {:pre [(instance? PrintWriter sniffer)]}
   (let [buffer (.getBuffer (get-writer sniffer))]
     (.setLength buffer 0)))
 
 (defn extract-all-lines-but-last! [sniffer]
-  {:pre  [(instance? PrintWriter sniffer)]}
+  {:pre [(instance? PrintWriter sniffer)]}
   (let [content (.toString (get-writer sniffer))]
     (if-not (empty? content)
       (let [lines (string/split content #"\n" -1)                                                                             ; http://stackoverflow.com/a/29614863/84283
@@ -90,7 +91,7 @@
         (string/join "\n" lines-ready)))))
 
 (defn extract-content! [sniffer]
-  {:pre  [(instance? PrintWriter sniffer)]}
+  {:pre [(instance? PrintWriter sniffer)]}
   (let [content (.toString (get-writer sniffer))]
     (when-not (empty? content)
       (clear-content! sniffer)

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -4,6 +4,7 @@
    [figwheel-sidecar.config :as config]
    [figwheel-sidecar.repl :refer [repl-println] :as frepl]   
 
+   [figwheel-sidecar.protocols :refer [ChannelServer] :as protocols]
    [figwheel-sidecar.components.nrepl-server    :as nrepl-comp]
    [figwheel-sidecar.components.css-watcher     :as css-watch]
    [figwheel-sidecar.components.cljs-autobuild  :as autobuild]
@@ -11,10 +12,7 @@
    
    [com.stuartsierra.component :as component]
 
-   [cljs.env :as env]
-
-   [clojure.pprint :as p]   
-   [clojure.java.io :as io]
+   [clojure.pprint :as p]
    [clojure.set :refer [difference union intersection]]
    [clojure.string :as string]))
 
@@ -123,12 +121,12 @@
         (swap! system component/stop)
         (assoc this :system-running false))
       this))
-  server/ChannelServer
+  ChannelServer
   (-send-message [this channel-id msg-data callback]
-    (server/-send-message (:figwheel-server @system)
+    (protocols/-send-message (:figwheel-server @system)
                    channel-id msg-data callback))
   (-connection-data [this]
-    (server/-connection-data (:figwheel-server @system))))
+    (protocols/-connection-data (:figwheel-server @system))))
 
 (defn figwheel-system [{:keys [build-ids] :as options}]
   (let [system

--- a/support/project.clj
+++ b/support/project.clj
@@ -10,4 +10,5 @@
   [[org.clojure/clojure "1.7.0"]
    [org.clojure/clojurescript "1.7.170"
     :exclusions [org.apache.ant/ant]]
+   [com.cognitect/transit-cljs "0.8.232"]
    [org.clojure/core.async "0.2.374"]])

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -1,5 +1,6 @@
 (ns ^:figwheel-no-load figwheel.client.utils
-    (:require [clojure.string :as string])
+    (:require [clojure.string :as string]
+              [goog.userAgent.product :as product])
     (:import [goog]))
 
 ;; don't auto reload this file it will mess up the debug printing
@@ -44,3 +45,46 @@
   (if eval-fn
     (eval-fn code opts)
     (js* "eval(~{code})")))
+
+(defn truncate-stack-trace [stack-str]
+  (take-while #(not (re-matches #".*eval_javascript_STAR__STAR_.*" %))
+              (string/split-lines stack-str)))
+
+(defn get-ua-product []
+  (cond
+    (node-env?) :chrome
+    product/SAFARI :safari
+    product/CHROME :chrome
+    product/FIREFOX :firefox
+    product/IE :ie))
+
+(def base-path (base-url-path))
+
+(defn eval-javascript** [code repl-print-fn opts result-handler]
+  (try
+    (binding [*print-fn* repl-print-fn
+              *print-newline* false]
+      (result-handler
+        {:status     :success,
+         :ua-product (get-ua-product)
+         :value      (eval-helper code opts)}))
+    (catch js/Error e
+      (result-handler
+        {:status     :exception
+         :value      (pr-str e)
+         :ua-product (get-ua-product)
+         :stacktrace (string/join "\n" (truncate-stack-trace (.-stack e)))
+         :base-path  base-path}))
+    (catch :default e
+      (result-handler
+        {:status     :exception
+         :ua-product (get-ua-product)
+         :value      (pr-str e)
+         :stacktrace "No stacktrace available."}))))
+
+(defn ensure-cljs-user
+  "The REPL can disconnect and reconnect lets ensure cljs.user exists at least."
+  []
+  ;; this should be included in the REPL
+  (when-not js/cljs.user
+    (set! js/cljs.user #js {})))

--- a/support/src/figwheel/plugin/repl_driver.cljs
+++ b/support/src/figwheel/plugin/repl_driver.cljs
@@ -1,0 +1,53 @@
+(ns figwheel.plugin.repl-driver
+  (:require
+    [figwheel.client.socket :as socket]))
+
+(def subscribers (atom []))
+
+; -- subscribers ------------------------------------------------------------------------------------------------------------
+
+(defn has-subscriber? [state subscriber]
+  (boolean (some #(= subscriber %) state)))
+
+(defn add-subscriber! [state subscriber]
+  (assert (not (has-subscriber? state subscriber)))
+  (conj state subscriber))
+
+(defn remove-subscriber! [state subscriber]
+  (assert (has-subscriber? state subscriber))
+  (remove #(= subscriber %) state))
+
+; -- handler for incoming server messages -----------------------------------------------------------------------------------
+
+(defn handle-message [msg opts]
+  (doseq [subscriber @subscribers]
+    (subscriber msg opts)))
+
+; -- low-level sending ------------------------------------------------------------------------------------------------------
+
+(defn send-message! [command opts]
+  (socket/send! (merge opts
+                       {:figwheel-event "repl-driver"
+                        :command        command})))
+
+; -- API available for client use -------------------------------------------------------------------------------------------
+
+(defn ^:export subscribe [subscriber-callback]
+  (swap! subscribers add-subscriber! subscriber-callback))
+
+(defn ^:export unsubscribe [subscriber-callback]
+  (swap! subscribers remove-subscriber! subscriber-callback))
+
+(defn ^:export is-socket-connected []
+  (socket/connected?))
+
+(defn ^:export is-repl-available []
+  true)                                                                                                                       ; TODO: detect repl availablity somehow
+
+(defn ^:export eval [request-id code & [user-input]]
+  (send-message! "eval" {:request-id request-id
+                         :code       code
+                         :input      (or user-input code)}))
+
+(defn ^:export request-ns []
+  (send-message! "request-ns" {}))

--- a/support/src/figwheel/plugin/repl_driver.cljs
+++ b/support/src/figwheel/plugin/repl_driver.cljs
@@ -9,11 +9,11 @@
 (defn has-subscriber? [state subscriber]
   (boolean (some #(= subscriber %) state)))
 
-(defn add-subscriber! [state subscriber]
+(defn add-subscriber [state subscriber]
   (assert (not (has-subscriber? state subscriber)))
   (conj state subscriber))
 
-(defn remove-subscriber! [state subscriber]
+(defn remove-subscriber [state subscriber]
   (assert (has-subscriber? state subscriber))
   (remove #(= subscriber %) state))
 
@@ -33,10 +33,10 @@
 ; -- API available for client use -------------------------------------------------------------------------------------------
 
 (defn ^:export subscribe [subscriber-callback]
-  (swap! subscribers add-subscriber! subscriber-callback))
+  (swap! subscribers add-subscriber subscriber-callback))
 
 (defn ^:export unsubscribe [subscriber-callback]
-  (swap! subscribers remove-subscriber! subscriber-callback))
+  (swap! subscribers remove-subscriber subscriber-callback))
 
 (defn ^:export is-socket-connected []
   (socket/connected?))


### PR DESCRIPTION
I want to be able to type REPL commands in devtools and let them compile & execute by figwheel.

This is a motivational screenshot from proof-of-concept code:
![Works like a magic](https://dl.dropboxusercontent.com/u/559047/cljs-devtools-repl-02.png)


Devtools could have used nREPL interface, but that was too hard. There is currently no clojurescript implementation of nREPL client and whole nREPL landscape seems to be a mess.

Instead I decided to talk directly to Figwheel and use its already existing connection.

This pull request is not meant to be merged. I just want to open discussion what is the best approach to implement something like this. 

Open questions:
1) Does figwheel want to provide such service to cljs-devtools in the first place?
2) Should that functionality by automatic or configure via a plugin
3) What should be the story for multiple repl sessions? Current implementation simply pastes whatever comes over wire into current REPL session (which is ok solution for now IMO). An alternative solution would be to deliver REPL commands only if REPL session matches build-id of issuing client. I didn't see any infrastructure in figwheel to decide on incoming websocket messages depending from which build-id they are coming.

Note: echoing REPL results back to devtools is not directly related to this PR, it is done via
https://github.com/binaryage/cljs-devtools/wiki/Figwheel-REPL-plugin