### PR TITLE
Use :system-running in figwheel-running?

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl_api.clj
+++ b/sidecar/src/figwheel_sidecar/repl_api.clj
@@ -29,7 +29,7 @@
     (alter-var-root #'*repl-api-system* component/stop)))
 
 (defn figwheel-running? []
-  (or *repl-api-system*
+  (or (get-in *repl-api-system* [:figwheel-system :system-running] false)
       (do
         (println "Figwheel System not itnitialized.\nPlease start it with figwheel-sidecar.repl-api/start-figwheel!")
         nil)))
@@ -126,4 +126,4 @@ the first default id)."
     (if (false? (:repl figwheel-options))
       (loop [] (Thread/sleep 30000) (recur))
       ;; really should get the given initial build id here
-      (fs/cljs-repl (:figwheel-system system))))) 
+      (fs/cljs-repl (:figwheel-system system)))))


### PR DESCRIPTION
This is in response to a bug I encountered where running `cljs-repl` after starting and stopping the figwheel component would cause the repl to hang indefinitely.

This is because the `figwheel-running?` function depends on the truthy value of the *repl-api-system* var, which is nil (false) initially, a running component (true) after starting and a not-running component (still true) after stopping.

This PR change the `figwheel-running?` function to use the `*repl-api-system*` > `:figwheel-system` > `:system-running` boolean, which will be nil before the component has been started, true after starting, and then false after stopping.

To reproduce, start a repl and then:

```
user> (ra/start-figwheel! config)
Figwheel: Starting server at http://localhost:3449
Figwheel: Watching build - dev
Compiling "resources/public/js/main.js" from ["src/cljs"]...
Successfully compiled "resources/public/js/main.js" in 3.439 seconds.
Figwheel: Starting CSS Watcher for paths  ["resources/public/css"]
#<SystemMap>
user> (ra/stop-figwheel!)
Figwheel: Stopped watching CSS Watcher paths  ["resources/public/css"]
Figwheel: Stopped watching build - dev
Figwheel: Stopping Websocket Server
#<SystemMap>
user> (ra/cljs-repl)
Launching ClojureScript REPL for build: dev
Figwheel Controls:
          (stop-autobuild)                ;; stops Figwheel autobuilder
          (start-autobuild [id ...])      ;; starts autobuilder focused on optional ids
          (switch-to-build id ...)        ;; switches autobuilder to different build
          (reset-autobuild)               ;; stops, cleans, and starts autobuilder
          (reload-config)                 ;; reloads build config and resets autobuild
          (build-once [id ...])           ;; builds source one time
          (clean-builds [id ..])          ;; deletes compiled cljs target files
          (print-config [id ...])         ;; prints out build configurations
          (fig-status)                    ;; displays current state of system
  Switch REPL build focus:
          :cljs/quit                      ;; allows you to switch REPL to another build
    Docs: (doc function-name-here)
    Exit: Control+C or :cljs/quit
 Results: Stored in vars *1, *2, *3, *e holds last exception object
Prompt will show when Figwheel connects to your application
```