### PR TITLE
Introduce :http-server-path option for customizing the server path

### DIFF
--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -178,6 +178,7 @@
     cljs-compiler-rules
     (spec 'FigwheelOptions
           {:http-server-root  string?
+           :http-server-path  string?
                                         ; :builds            (ref-schema 'FigwheelOnlyBuilds)
            :server-port       integer?
            :server-ip         string?

--- a/sidecar/src/figwheel_sidecar/utils.clj
+++ b/sidecar/src/figwheel_sidecar/utils.clj
@@ -79,6 +79,7 @@
     (swap! env-atom #(vary-meta % assoc :type ::compiler-env))
     env-atom))
 
-
-
-
+(defn normalize-path
+  "Adds a / if missing at the end of the path."
+  [path]
+  (str path (when-not (= "/" (last path)) "/")))


### PR DESCRIPTION
Never again hard coded resource folder for figwheel projects!

This patch introduces a server option, :http-server-path, which, together with its cousin
`:http-server-root`, will form the path that figwheel will serve from the project folder.

It needs to be a string, it is unique (only one figwheel server conf per project) and defaults to
"resources/".