### PR TITLE
Mirrors attribute not honoured in plugin sub-project

### DIFF
--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -17,6 +17,7 @@
                             :local-repo
                             :dependencies
                             :repositories
+                            :mirrors
                             :resource-paths])
       {:local-repo-classpath true
        :source-paths (concat


### PR DESCRIPTION
Many thanks for all the great work on figwheel!

I'm using artifactory as a proxy repository and have it configured as a mirror in `project.clj`. Dependency resolution is failing with fighweel as its ignoring my configured mirror.

The fighweel plugin creates a subproject to compile the cljs files in the same way lein-cljsbuild does. lein-cljsbuild was updated to include the `:mirrors` key, but fighweel hasn't been updated in the same way.

This patch adds the `:mirrors` attribute to the sub-project. Its essentially the same change as was applied to lein-cljsbuild here:
https://github.com/emezeske/lein-cljsbuild/commit/51465ed685c8ba7121337970fc711ad4369a2163