### PR TITLE
Adding checks to ensure that localstorage and document actually exist…

### DIFF
--- a/support/src/figwheel/client.cljs
+++ b/support/src/figwheel/client.cljs
@@ -26,7 +26,8 @@
   (if (utils/html-env?)
     (fn []
       (condp = (or (try
-                     (.getItem js/localStorage "figwheel_autoload")
+                     (when (js* "typeof localstorage !== 'undefined'")
+                       (.getItem js/localStorage "figwheel_autoload"))
                      (catch js/Error e
                        false))
                    "true")
@@ -37,7 +38,8 @@
 (defn ^:export toggle-autoload []
   (when (utils/html-env?)
     (try
-      (.setItem js/localStorage "figwheel_autoload" (not (autoload?)))
+      (when (js* "typeof localstorage !== 'undefined'")
+        (.setItem js/localStorage "figwheel_autoload" (not (autoload?))))
       (utils/log :info
                  (str "Figwheel autoloading " (if (autoload?) "ON" "OFF")))
       (catch js/Error e

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -17,7 +17,7 @@
 ;; actually we should probably lift the event system here off the DOM
 ;; so that we work well in Node and other environments
 (defn dispatch-custom-event [event-name data]
-  (when (and (html-env?) (aget js/window "CustomEvent"))
+  (when (and (html-env?) (aget js/window "CustomEvent") (js* "typeof document !== 'undefined'"))
     (.dispatchEvent (.-body js/document)
                     (js/CustomEvent. event-name
                                      (js-obj "detail" data)))))


### PR DESCRIPTION
Ran into a problem when using figwheel on a [re-natal](https://github.com/drapanjanas/re-natal) project.  The problems stemmed from some re-natal code shimming the `localstorage` and `document` variables (which don't exist in react-native land).

[figwheel-bridge.js](https://github.com/drapanjanas/re-natal/blob/master/resources/figwheel-bridge.js):
```javascript
function fakeLocalStorageAndDocument() {
    window.localStorage = {};
    window.localStorage.getItem = function () {
        return 'true';
    };
    window.localStorage.setItem = function () {
    };

    window.document = {};
    window.document.body = {};
    window.document.body.dispatchEvent = function () {
    };
    window.document.createElement = function () {
    };

    if (typeof window.location === 'undefined') {
        window.location = {};
    }
    console.debug = console.warn;
    window.addEventListener = function () {
    };
    // make figwheel think that heads-up-display divs are there
    window.document.querySelector = function (selector) {
        return {};
    };
    window.document.getElementById = function (id) {
        return {style:{}};
    };
}
```
This shim actually broke Firebase functionality (still not sure why, but it has something to do with faking the `document` object.  Normally I'd present a patch to `re-natal`, but the shim is just to patch figwheel so I figured I'd just fix the root problem.  :)

Also, wanted to thank you for the excellent work you've done on Figwheel.  I don't think I could do clojurescript development on react-native without it.  