### PR TITLE
Set profiles on project when loading in validation loop

### DIFF
--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -46,8 +46,8 @@
 (defn- run-local-project [project builds requires form]
   (let [project' (-> project
                    (update-in [:dependencies] conj ['figwheel-sidecar figwheel-sidecar-version])
-                   (update-in [:dependencies] conj ['figwheel figwheel-version]) 
-                   (make-subproject builds))] 
+                   (update-in [:dependencies] conj ['figwheel figwheel-version])
+                   (make-subproject builds))]
     (leval/eval-in-project project'
      `(try
         (do
@@ -80,16 +80,19 @@
              (get config-data :validate-config)
              (get-in config-data [:figwheel :validate-config])))))
 
-(defn validate-figwheel-conf-helper []
+(defn validate-figwheel-conf-helper [project]
   (when-let [validate-loop (resolve 'figwheel-sidecar.config-check.validate-config/validate-loop)]
     (if (figwheel-edn?)
       (validate-loop
-       (fn [] (slurp "figwheel.edn"))
-       {:file (io/file "figwheel.edn")
-        :figwheel-options-only true})
+        (repeatedly #(slurp "figwheel.edn"))
+        {:file (io/file "figwheel.edn")
+         :figwheel-options-only true})
       (validate-loop
-       (fn [] (lproj/read))
-       {:file (io/file "project.clj")}))))
+        (cons project
+              (repeatedly #(lproj/set-profiles (lproj/read)
+                                               (:included-profiles (meta project))
+                                               (:excluded-profiles (meta project)))))
+        {:file (io/file "project.clj")}))))
 
 (defn validate-figwheel-conf [project]
   (let [config-data (config-data project)]
@@ -97,7 +100,7 @@
       config-data
       (do
         (require 'figwheel-sidecar.config-check.validate-config)
-        (if-let [config (validate-figwheel-conf-helper)]
+        (if-let [config (validate-figwheel-conf-helper project)]
           (do (println "\nFigwheel: Configuration Valid. Starting Figwheel ...")
               config)
           (do (println "\nFigwheel: Configuration validation failed. Exiting ...")
@@ -117,7 +120,7 @@
                                    all-builds
                                    build-ids))]
       (if (empty? errors)
-        (run-compiler project 
+        (run-compiler project
                       { :figwheel-options figwheel-options
                         :all-builds all-builds
                         :build-ids  (vec build-ids)})

--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -419,7 +419,7 @@
             (get-choice choices))
           ch)))))
 
-(defn validate-loop [get-data-fn options]
+(defn validate-loop [projects options]
   (let [{:keys [figwheel-options-only file]} options]
     (if-not (.exists (io/file file))
       (do
@@ -427,8 +427,9 @@
         (System/exit 1))
       (let [file (io/file file)]
         (println "Figwheel: Validating the configuration found in" (str file))
-        (loop [fix false]
-          (let [config (get-data-fn)]
+        (loop [fix false
+               projects projects]
+          (let [config (first projects)]
             (if (not (validate-config-data config figwheel-options-only))
               config
               (do
@@ -450,10 +451,10 @@
                           (do
                             (println "Figwheel: Waiting for you to edit and save your" (str file) "file ...")
                             (file-change-wait file (* 120 1000))
-                            (recur true))
+                            (recur true (rest projects)))
                           (do ;; this branch shouldn't be taken
                             (Thread/sleep 1000)
-                            (recur true)))))))))))))
+                            (recur true (rest projects))))))))))))))
 
 (comment
   ;; figure out


### PR DESCRIPTION
I'm using profiles to split up by cljsbuild maps in project.clj. Figwheel is reloading the project map in the validation loop but it's not re-applying the profiles so cljsbuilds within profiles can't be found.

This PR calls lproj/set-profiles on the project map. The included and excluded profiles are extracted from the object metadata of the project.

There is a potential problem with this. Leiningen does a lot of work inside set-profiles, including applying plugins, resolving dependencies and applying middleware. I'm guessing its ok to do this repeatedly from within a plugin, but I'm not sure.  This does seem to be the only way to be really sure that figwheel is receiving a true project map after plugins and profiles have been applied.

One thought I had was  figwheel could do the initial validation on the original project map that was passed to the plugin and only reload the project if there were configuration problems. This would at least minimise any potential issues with reloading the project map.

Even though I'm not 100% confident in this change, I thought I'd create the PR anyway incase you had some thoughts.