### PR TITLE
Allows the passage of :server-opts to configure the http-kit server.

### DIFF
--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -103,7 +103,7 @@
 (defn server
   "This is the server. It is complected and its OK. Its trying to be a basic devel server and
    also provides the figwheel websocket connection."
-  [{:keys [server-port server-ip http-server-root resolved-ring-handler] :as server-state}]
+  [{:keys [server-port server-ip server-opts http-server-root resolved-ring-handler] :as server-state}]
   (try
     (-> (routes
          (GET "/figwheel-ws/:desired-build-id" {params :params} (reload-handler server-state))
@@ -117,7 +117,7 @@
         (cors/wrap-cors
          :access-control-allow-origin #".*"
          :access-control-allow-methods [:head :options :get :put :post :delete :patch])
-        (run-server (let [config {:port server-port :worker-name-prefix "figwh-httpkit-"}]
+        (run-server (let [config (merge server-opts {:port server-port :worker-name-prefix "figwh-httpkit-"})]
                       (if server-ip
                         (assoc config :ip server-ip)
                         config))))

--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -168,6 +168,8 @@
            ; :builds is added below
            :server-port       integer?
            :server-ip         string?
+           :server-logfile    string?
+           :server-opts       map?
            :css-dirs          [string?]
            :ring-handler      (ref-schema 'Named)
            :reload-clj-files  (ref-schema 'ReloadCljFiles)

--- a/sidecar/test/figwheel_sidecar/config_check/type_check_test.clj
+++ b/sidecar/test/figwheel_sidecar/config_check/type_check_test.clj
@@ -35,6 +35,7 @@
    (spec 'FigwheelOptions
          {:server-port integer?
           :server-ip   string?
+          :server-opts map?
           :source-paths [string?]})))
 
 (deftest basic-passing
@@ -45,12 +46,14 @@
     (is (empty? (type-checker 'RootMap {:static :huh?} {})))    
     (is (empty? (type-checker 'RootMap {:figwheel {:server-port 5}} {})))
     (is (empty? (type-checker 'RootMap {:figwheel {:server-ip "asdf"}} {})))
+    (is (empty? (type-checker 'RootMap {:figwheel {:server-opts {}}} {})))
     (is (empty? (type-checker 'RootMap {:figwheel {:source-paths []}} {})))
     (is (empty? (type-checker 'RootMap {:figwheel {:source-paths ["asdf" "asdf" "asdf"]}} {})))
     (is (empty? (type-checker 'RootMap {:cljsbuild {:repl-listen-port 5}} {})))
     (is (empty? (type-checker 'RootMap {:cljsbuild {:crossovers 5}} {})))
     (is (empty? (type-checker 'RootMap {:figwheel {:server-port 5
                                                    :server-ip "asdf"
+                                                   :server-opts {}
                                                    :source-paths ["asdf" "asdf" "asdf"]}
                                         :cljsbuild {:repl-listen-port 5
                                                     :crossovers 5}


### PR DESCRIPTION
This is most useful for allowing the configuration of the `:max-body` option for http-kit.

Also, fixes the configuration check for :server-logfile