### PR TITLE
Support :server-ip and :server-hostname as values for :websocket-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,16 +336,23 @@ The following configuration options are available:
 
 ```clojure
 
-;; configure a websocket host, figwheel already knows the port
-;; this is helpful if you want to broadcast to devices
-:websocket-host "localhost" ;; or "www.myhost.com", "192.168.0.112"
-
-;; An important configuration option for :websocket-host
-;; if you set it to :js-client-host it will set the host based on the
-;; js/location.host param of the browser
-;; This is helpful for multiple device settings where you are using
-;; fighweel to serve your app.
-;; :websocket-host :js-client-host
+;; Configure :websocket-host for the figwheel js client to connect to.
+;; (Don't specify the port; figwheel already knows it).
+;; Defaults to "localhost".  Valid values are:
+;; 
+;;   <any-string>      Uses that exact string as hostname.
+;;
+;;   :js-client-host   Uses window.location.host from JS.  This is useful when connecting
+;;                     from a different device/computer on your LAN, e.g. testing mobile
+;;                     safari.
+;;
+;;   :server-ip        Uses the IP address of the figwheel server.  This is Useful in special
+;;                     situations like an iOS (WK)WebView.  Be sure to check your CORS headers.
+;;
+;;   :server-hostname  Like :server-ip, but uses hostname string rather than IP address.
+;;                     (On unix, check that `hostname` outputs the right string in shell).
+;;
+:websocket-host :js-client-host
 
 ;; optional callback
 :on-jsload "example.core/fig-reload"

--- a/sidecar/resources/conf-fig-docs/FigwheelClientOptions.txt
+++ b/sidecar/resources/conf-fig-docs/FigwheelClientOptions.txt
@@ -8,14 +8,16 @@ want the figwheel client code to be injected into the build.
 
 :websocket-host
 
-A String specifying the host part of the Figwheel websocket URL. If
-you have JavaScript clients that need to access Figwheel that are not
-local, you can supply the IP address of your machine here. You can
-also specify :js-client-host and the Figwheel client will use the
-js/location.host of the client.
+A String specifying the host part of the Figwheel websocket URL. If you have
+JavaScript clients that need to access Figwheel that are not local, you can
+supply the IP address of your machine here, or you can specify one of the
+following keywords to have figwheel determine the string for you.
+  :js-client-host  -- will use js/window.location.host
+  :server-ip       -- will use local IP address of figwheel server
+  :server-hostname -- will do a local hostname lookup on figwheel server
 Default: "localhost"
 
-  :websocket-host "192.168.1.101"
+  :websocket-host :server-ip
 
 :on-jsload
 

--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -231,7 +231,7 @@
               :retry-count         integer?
               :devcards            (ref-schema 'Boolean)
               :eval-fn             (ref-schema 'Named)})
-    (or-spec 'WebsocketHost :js-client-host string?)
+    (or-spec 'WebsocketHost :js-client-host :server-ip :server-hostname string?)
     (get-docs
      ['CompilerOptions
       'FigwheelOptions


### PR DESCRIPTION
Here's my crack at allowing `{:websocket-host :server-ip}` (see #368).

This is a draft for feedback.  If you like it, I will add to this PR updates to `README.md`, `CHANGES.md`, and `FigwheelClientOptions.txt`. 

In the course of implementing this, I found `update-figwheel-connect-options` to be a bit hard to follow, so I endeavored to make it a little easier to think about.  In the process, there was a slight behavior change: now if both `:websocket-host` and `:websocket-url` are supplied, it dissoc'es `:websocket-host` (previously did not).
