### PR TITLE
add missing :compiler option :closure-output-charset

### DIFF
--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -121,7 +121,8 @@
           :source-map-inline         (ref-schema 'Boolean)
           :ups-libs                  [string?]
           :ups-externs               [string?]
-          :ups-foreign-libs          [(ref-schema 'ForeignLib)]})
+          :ups-foreign-libs          [(ref-schema 'ForeignLib)]
+          :closure-output-charset    string?})
     (spec 'ForeignLib {:file string?
                        :provides [string?]
                        :file-min string?


### PR DESCRIPTION
It will be hard to keep up with various "undocumented" options in the ClojureScript codebase. Would be great if ClojureScript itself could tell us what is the schema of compiler options.

FYI, the backstory why I needed to use this one is here:
http://dev.clojure.org/jira/browse/CLJS-1547?focusedCommentId=42617

