### PR TITLE
introduce :initial-notify-command

### DIFF
--- a/sidecar/resources/conf-fig-docs/BuildOptionsMap.txt
+++ b/sidecar/resources/conf-fig-docs/BuildOptionsMap.txt
@@ -30,3 +30,11 @@ Default: nil (disabled)
 
   :notify-command ["growlnotify" "-m"]
 
+:initial-notify-command
+
+This option works like :notify-command, but specifies a command to be called
+after initial compilation. :notify-command is called only for compilations
+triggered in reaction to file changes.
+Default: nil (disabled)
+
+  :initial-notify-command ["growlnotify" "-m"]

--- a/sidecar/resources/conf-fig-docs/FigwheelClientOptions.txt
+++ b/sidecar/resources/conf-fig-docs/FigwheelClientOptions.txt
@@ -53,3 +53,12 @@ small shell script wrapper.
 Default: nil (disabled)
 
   :notify-command ["growlnotify" "-m"]
+
+:initial-notify-command
+
+This option works like :notify-command, but specifies a command to be called
+after initial compilation. :notify-command is called only for compilations
+triggered in reaction to file changes.
+Default: nil (disabled)
+
+  :initial-notify-command ["growlnotify" "-m"]

--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -202,15 +202,16 @@
              [(ref-schema 'BuildOptionsMap)]
              {named? (ref-schema 'BuildOptionsMap)})
     (spec 'BuildOptionsMap
-          { :id              (ref-schema 'Named)
-            :source-paths    [string?]
-            :figwheel        (ref-schema 'FigwheelClientOptions)
-            :compiler        (ref-schema 'CompilerOptions)
-            :notify-command  [string?]
-            :jar             (ref-schema 'Boolean)
-            :incremental     (ref-schema 'Boolean)
-            :assert          (ref-schema 'Boolean)
-            :warning-handlers [anything?]
+          {:id                     (ref-schema 'Named)
+           :source-paths           [string?]
+           :figwheel               (ref-schema 'FigwheelClientOptions)
+           :compiler               (ref-schema 'CompilerOptions)
+           :notify-command         [string?]
+           :initial-notify-command [string?]
+           :jar                    (ref-schema 'Boolean)
+           :incremental            (ref-schema 'Boolean)
+           :assert                 (ref-schema 'Boolean)
+           :warning-handlers       [anything?]
            })
     (assert-not-empty 'BuildOptionsMap :source-paths)
     (requires-keys 'BuildOptionsMap :source-paths :compiler)


### PR DESCRIPTION
This just a proposal to introduce a way how to notify that initial build finished.

I don't know what was the original reasoning behind disabling it for initial builds. But I think figwheel's behaviour is now inconsistent with `cljsbuild auto` behaviour. 

Also figwheel does not pass any information to the command. I guess the docs `textual description of what happened will be appended as the last argument to the command` were probably copy&pasted from cljsbuild.