### PR TITLE
Listen on 0.0.0.0 instead of localhost by default

### DIFF
--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -157,7 +157,7 @@
         :unique-id (or unique-id (.getCanonicalPath (io/file "."))) 
         :http-server-root (or http-server-root "public")
         :server-port (or server-port 3449)
-        :server-ip (or server-ip "localhost")
+        :server-ip (or server-ip "0.0.0.0")
         :ring-handler ring-handler
         ;; TODO handle this better
         :resolved-ring-handler (or resolved-ring-handler


### PR DESCRIPTION
I usually run Figwheel from the [clojure](https://hub.docker.com/_/clojure/) docker image. Listening on `localhost` doesn't work, so I'd have to override this for every project. [http-kit](http://www.http-kit.org/server.html) uses 0.0.0.0 by default, and I would argue it is preferred.