### PR TITLE
Only collect source-paths from specified builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ side configuration parameters:
    ;; if your project.clj contains conflicting builds,
    ;; you can choose to only load the builds specified
    ;; on the command line
-   ;; :all-builds false ; default is true
+   ;; :load-all-builds false ; default is true
 } 
 ```
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,11 @@ side configuration parameters:
    ;; if you need to watch files with polling instead of FS events
    ;; :hawk-options {:watcher :polling}     
    ;; ^ this can be useful in Docker environments
- 
+
+   ;; if your project.clj contains conflicting builds,
+   ;; you can choose to only load the builds specified
+   ;; on the command line
+   ;; :all-builds false ; default is true
 } 
 ```
 

--- a/example/project.clj
+++ b/example/project.clj
@@ -141,5 +141,5 @@
              ;; if your project.clj contains conflicting builds,
              ;; you can choose to only load the builds specified
              ;; on the command line
-             ;; :all-builds false ; default is true
+             ;; :load-all-builds false ; default is true
              })

--- a/example/project.clj
+++ b/example/project.clj
@@ -136,6 +136,10 @@
              ;; :ring-handler example.server/handler
 
              ;; if you need polling instead of FS events
-             ;; :hawk-options {:watcher :polling} 
-             
+             ;; :hawk-options {:watcher :polling}
+
+             ;; if your project.clj contains conflicting builds,
+             ;; you can choose to only load the builds specified
+             ;; on the command line
+             ;; :all-builds false ; default is true
              })

--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -112,10 +112,10 @@
 
 (defn autobuild-opts [figwheel-options all-builds build-ids]
   {:build-ids (vec build-ids)
-   :all-builds (if (:all-builds figwheel-options)
+   :all-builds (if (:load-all-builds figwheel-options)
                  all-builds
                  (into [] (filter #(contains? (set build-ids) (:id %))) all-builds))
-   :figwheel-options (dissoc figwheel-options :all-builds)})
+   :figwheel-options (dissoc figwheel-options :load-all-builds)})
 
 (defn figwheel
   "Autocompile ClojureScript and serve the changes over a websocket (+ plus static file server)."

--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -56,16 +56,20 @@
         (catch Exception e#
           (do
             (.printStackTrace e#)
-           (System/exit 1))))
+            (System/exit 1))))
      requires)))
 
 (defn run-compiler [project {:keys [all-builds build-ids] :as autobuild-opts}]
-  (run-local-project
-   project all-builds
-   '(require 'figwheel-sidecar.repl-api)
-   `(do
-      (figwheel-sidecar.repl-api/system-asserts)
-      (figwheel-sidecar.repl-api/start-figwheel-from-lein '~autobuild-opts))))
+  (if (empty? all-builds)
+    (do
+      (println "\nFigwheel: No builds detected. Exiting ...")
+      (System/exit 1))
+    (run-local-project
+     project all-builds
+     '(require 'figwheel-sidecar.repl-api)
+     `(do
+        (figwheel-sidecar.repl-api/system-asserts)
+        (figwheel-sidecar.repl-api/start-figwheel-from-lein '~autobuild-opts)))))
 
 (defn figwheel-edn? [] (.exists (io/file "figwheel.edn")))
 

--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -60,12 +60,13 @@
      requires)))
 
 (defn run-compiler [project {:keys [all-builds build-ids] :as autobuild-opts}]
-  (run-local-project
-   project all-builds
-   '(require 'figwheel-sidecar.repl-api)
-   `(do
-      (figwheel-sidecar.repl-api/system-asserts)
-      (figwheel-sidecar.repl-api/start-figwheel-from-lein '~autobuild-opts))))
+  (let [builds (into [] (filter #(contains? (set build-ids) (:id %))) all-builds)]
+    (run-local-project
+     project builds
+     '(require 'figwheel-sidecar.repl-api)
+     `(do
+        (figwheel-sidecar.repl-api/system-asserts)
+        (figwheel-sidecar.repl-api/start-figwheel-from-lein '~autobuild-opts)))))
 
 (defn figwheel-edn? [] (.exists (io/file "figwheel.edn")))
 

--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -183,7 +183,8 @@
            :nrepl-host        string?
            :hawk-options      (ref-schema 'HawkOptionsMap)
            :nrepl-middleware  [(ref-schema 'Named)]
-           :validate-config   (ref-schema 'Boolean)})
+           :validate-config   (ref-schema 'Boolean)
+           :all-builds        (ref-schema 'Boolean)})
     (spec 'HawkOptionsMap {:watcher (ref-schema 'HawkWatcher)})
     (or-spec 'HawkWatcher :barbary :java :polling)
     (or-spec 'ReloadCljFiles

--- a/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
+++ b/sidecar/src/figwheel_sidecar/config_check/validate_config.clj
@@ -184,7 +184,7 @@
            :hawk-options      (ref-schema 'HawkOptionsMap)
            :nrepl-middleware  [(ref-schema 'Named)]
            :validate-config   (ref-schema 'Boolean)
-           :all-builds        (ref-schema 'Boolean)})
+           :load-all-builds   (ref-schema 'Boolean)})
     (spec 'HawkOptionsMap {:watcher (ref-schema 'HawkWatcher)})
     (or-spec 'HawkWatcher :barbary :java :polling)
     (or-spec 'ReloadCljFiles


### PR DESCRIPTION
Thanks so much for your great work on Figwheel!

Our `project.clj` contains builds that have incompatible source paths (some are builds with React Native, while others are builds for React). When we boot Figwheel, the current code pulls in all `source-paths` for all projects, even if those projects were not specified on the command line via `lein figwheel build1 build2`. This causes errors, because our web apps now include code that tries to reference React Native.

This branch changes the behavior so the only source-paths loaded are those from specified builds.