### PR TITLE
Arguments to open-file-command must be strings, not numeric.

### DIFF
--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -32,7 +32,8 @@
                     (when (not (nil? file-column))
                       (str ":" file-column))))
         true (conj file-name))
-      [open-file-command file-name file-line file-column])))
+      ;; must pass arguments to clojure.java.shell/sh as strings, not numeric values
+      [open-file-command file-name (str file-line) (str file-column)])))
 
 (defn read-msg [data]
   (try


### PR DESCRIPTION
Must pass arguments to clojure.java.shell/sh as strings, not numeric values. As non string values are filtered out. This then means that the example emacsclient script blowsup with: 

    Failed to call open file command:  ["figwheel-open" "src/njord/ui/menu.cljs" 5 1]
    ...
    *ERROR*: Invalid -position command in client args

Here is the output with this patch applied (note the line and column numbers are now strings):

    Successful open file command:  ["figwheel-open" "src/njord/ui/menu.cljs" "5" "1"]

Hope this is useful, thanks for figwheel :)