### PR TITLE
Add repl-api/repl-env for fireplace

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl_api.clj
+++ b/sidecar/src/figwheel_sidecar/repl_api.clj
@@ -112,6 +112,14 @@ the first default id)."
    (when (figwheel-running?)
      (fs/cljs-repl (:figwheel-system *repl-api-system*) id))))
 
+(defn repl-env
+  "Returns repl-env for use in editors with Piggieback support."
+  ([]
+   (repl-env nil))
+  ([id]
+   (when (figwheel-running?)
+     (fs/repl-env (:figwheel-system *repl-api-system*) id))))
+
 (defn fig-status
   "Display the current status of the running Figwheel system."
   []

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -574,6 +574,24 @@
        (figwheel-cljs-repl* system build-id repl-options) 
        (build-switching-cljs-repl* system build-id repl-options)))))
 
+(defn repl-env*
+  ([system] (repl-env* system nil))
+  ([system start-build-id] (repl-env* system nil {}))
+  ([system start-build-id repl-options]
+   (let [build-id (or
+                   start-build-id
+                   (initial-repl-focus-build-id @system))
+         {:keys [figwheel-server]} @system]
+     ;; from figwheel-cljs-repl*
+     (when-let [build (choose-repl-build @system build-id)]
+       ;; always used in nrepl
+       ;; from start-figwheel-repl
+       (frepl/cljs-repl-env
+         build
+         figwheel-server
+         (update-in repl-options [:special-fns]
+                    merge (build-figwheel-special-fns system)))))))
+
 ;; takes a FigwheelSystem
 (defn figwheel-cljs-repl
   ([figwheel-system]
@@ -601,6 +619,17 @@
                 start-build-id
                 (initial-repl-focus-build-id @system))
                repl-options)))
+
+(defn repl-env
+  ([figwheel-system] (repl-env figwheel-system nil {}))
+  ([figwheel-system start-build-id]
+   (repl-env figwheel-system start-build-id {}))
+  ([{:keys [system]} start-build-id repl-options]
+   (repl-env* system
+              (or
+               start-build-id
+               (initial-repl-focus-build-id @system))
+              repl-options)))
 
 ;; figwheel starting and stopping helpers
 


### PR DESCRIPTION
Fireplace currently calls `piggieback/cljs-repl` itself (https://github.com/tpope/vim-fireplace/blob/49d3aca64df0ee6ea529c08850fb42344407bcd3/plugin/fireplace.vim#L293) so the current `repl-api/cljs-repl` can't be used with it.

Alternative is that Fireplace adds support for using current cljs-repl, there is PR about this: https://github.com/tpope/vim-fireplace/pull/222

This change is quite simple but it duplicates some code, but this could be fixed with some refactoring, so that `cljs-repl` uses same path to create repl-env and then just calls piggieback.