### PR TITLE
Fix spec for modules

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -236,7 +236,7 @@ Defaults to the empty vector [].
 (def-key ::modules (s/map-of
                     keyword?
                     (strict-keys
-                     :req-un [:cljs.options-schema.modules/output-dir
+                     :req-un [:cljs.options-schema.modules/output-to
                               ::entries]
                      :opt-un [::depends-on]))
 
@@ -288,8 +288,8 @@ single source map to name.")
 ;; ** TODO name collision don't want docs to collide
 ;; this is the only name collision in this
 (def-key :cljs.options-schema.modules/output-dir    non-blank-string?)
-(def-key ::entries       (s/every non-blank-string? :min-count 1 :into [] :kind sequential?))
-(def-key ::depends-on    (s/every ::string-or-named :min-count 1 :into [] :kind sequential?))
+(def-key ::entries       (s/every ::string-or-symbol :min-count 1 :into [] :kind  (some-fn sequential? set?)))
+(def-key ::depends-on    (s/every ::string-or-named :min-count 1 :into [] :kind (some-fn sequential? set?)))
 
 (def-key ::source-map-path            string?
 


### PR DESCRIPTION
The spec for modules does not correctly specify the modules section of the ClojureScript compiler options. 

As an example, it currently fails to validate the modules example in the [ClojureScript documentation](https://github.com/clojure/clojurescript/wiki/Compiler-Options#modules). 

    ExceptionInfo ------ Figwheel Configuration Error ------

    It's likely that the key :output-to is misspelled. It should probably be :output-dir

    73                         :source-paths ["src_cljs" "src_cljc"]
    74                         :compiler {:optimizations :advanced
    75                                    :output-dir "resources/public/js"
    76                                    :modules {
    77                                              :common 
    78                                              {:output-to "resources/public/js/common.js"  
						    ^---
			The key :output-to should probably be :output-dir
    79                                               :entries #{"com.foo.common"}}
    80                                              :landing 
    81                                              {:output-to "resources/public/js/landing.js" 
    82                                               :entries #{"com.foo.landing"}
    83                                               :depends-on #{:common}}

    ------------------------------------------
    clojure.core/ex-info (core.clj:4617)


This pull request fixes the spec.