### PR TITLE
Expose clojurescript repl-env directly

### DIFF
--- a/sidecar/src/figwheel_sidecar/repl_api.clj
+++ b/sidecar/src/figwheel_sidecar/repl_api.clj
@@ -112,6 +112,14 @@ the first default id)."
    (when (figwheel-running?)
      (fs/cljs-repl (:figwheel-system *repl-api-system*) id))))
 
+(defn repl-env
+  "Returns repl-env for use in editors with Piggieback support."
+  ([]
+   (repl-env nil))
+  ([id]
+   (when (figwheel-running?)
+     (fs/repl-env (:figwheel-system *repl-api-system*) id))))
+
 (defn fig-status
   "Display the current status of the running Figwheel system."
   []


### PR DESCRIPTION
This is an alternative to, and builds heavily upon,
https://github.com/bhauman/lein-figwheel/pull/457 (big thanks to to
@Deraen)

It exposes the repl-env in the same way, and is intended for
vim-fireplace.

Example usage from vim-fireplace:
```vim
:Piggieback (figwheel-sidecar.repl-api/repl-env)
```

---

Tested via:
```
cd sidecar
lein repl
figwheel-sidecar.repl-api=> (def proj (config/->config-data (config/->lein-project-config-source)))
#'figwheel-sidecar.repl-api/proj
figwheel-sidecar.repl-api=> (launch-from-lein (:data proj) ["dev"])
```

in vim:

```
:Piggieback (figwheel-sidecar.repl-api/repl-env)
```

I was able to use `K` to view docs, evaluate code, and jump to source.