### PR TITLE
cljs.env causing alias error in clojure 1.9 alpha

### DIFF
--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -13,8 +13,6 @@
    [strictly-specking-standalone.ansi-util :refer [with-color-when color-text]]
    [com.stuartsierra.component :as component]
 
-   [cljs.env :as env]
-
    [clojure.pprint :as p]   
    [clojure.java.io :as io]
    [clojure.set :refer [difference union intersection]]


### PR DESCRIPTION
I was getting this error when using Figwheel with clojure-1.9.0-alpha12.

```
java.lang.IllegalStateException: Alias env already exists in namespace cljs.core, aliasing cljs.env
```

Not requiring `cljs.env` seems to fix it.