### PR TITLE
Add suggestion to error message in build options check

### DIFF
--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -149,7 +149,10 @@
      (filter identity
              (list
               (when-not opts?
-                "the build :optimizations key is set to something other than :none")
+                (string/join "\n"
+                  ["the build :optimizations key is set to something other than :none"
+                   "  probably you are trying to run figwheel with the production build"
+                   (str "  try to run `lein cljsbuild once " (pr-str (:id build')) "` instead")]))
               (when-not (:output-dir build-options)
                 "the build does not have an :output-dir key"))))))
 


### PR DESCRIPTION
Suggest users to run cljsbuild build in case they are trying to run figwheel using build with optimizations ebnabled
