### PR TITLE
Fix css reload race condition

### DIFF
--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -460,13 +460,13 @@
          :current-url-length (count (truncate-url link-href))}))))
 
 (defn get-correct-link [f-data]
-  (when-let [res (first
-                  (sort-by
-                   (fn [{:keys [match-length current-url-length]}]
-                     (- current-url-length match-length))
-                   (keep #(matches-file? f-data %)
-                         (current-links))))]
-    (:link res)))
+  (letfn [(match-quality [{:keys [match-length current-url-length]}]
+            (- current-url-length match-length))]
+    (->> (current-links)
+      (keep #(matches-file? f-data %))
+      (sort-by match-quality)
+      (partition-by match-quality)
+      (first) (last) (:link))))
 
 (defn clone-link [link url]
   (let [clone (.createElement js/document "link")]


### PR DESCRIPTION
Reloading the same css file in rapid succession causing a race condition because the original stylesheet link is targeted for removal first.  To solve, if there is multiple matching of the same length remove the last(oldest) link tag.