### PR TITLE
WebWorker client

### DIFF
--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -247,7 +247,7 @@
     :worker (fn [request-url callback]
               (dev-assert (string? request-url) (not (nil? callback)))
               (callback (try
-                          (do (.importScripts js/self request-url)
+                          (do (.importScripts js/self (add-cache-buster request-url))
                               true)
                           (catch js/Error e
                             (utils/log :error (str  "Figwheel: Error loading file " request-url))

--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -237,13 +237,22 @@
                         (utils/log :error (str  "Figwheel: Error loading file " cache-path))
                         (utils/log :error (.-stack e))
                         false))))))
-    
+
     :html (fn [request-url callback]
-            (dev-assert (string? request-url) (not (nil? callback)))  
+            (dev-assert (string? request-url) (not (nil? callback)))
             (let [deferred (loader/load (add-cache-buster request-url)
                                         #js { :cleanupWhenDone true })]
               (.addCallback deferred #(apply callback [true]))
               (.addErrback deferred #(apply callback [false]))))
+    :worker (fn [request-url callback]
+              (dev-assert (string? request-url) (not (nil? callback)))
+              (callback (try
+                          (do (.importScripts js/self request-url)
+                              true)
+                          (catch js/Error e
+                            (utils/log :error (str  "Figwheel: Error loading file " request-url))
+                            (utils/log :error (.-stack e))
+                            false))))
     (fn [a b] (throw "Reload not defined for this platform"))))
 
 (defn reload-file [{:keys [request-url] :as file-msg} callback]

--- a/support/src/figwheel/client/socket.cljs
+++ b/support/src/figwheel/client/socket.cljs
@@ -9,6 +9,7 @@
     (utils/node-env?) (try (js/require "ws")
                            (catch js/Error e
                              nil))
+    (utils/worker-env?) (aget js/self "WebSocket")
     :else nil))
 
 ;; messages have the following formats

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -11,7 +11,13 @@
 
 (defn node-env? [] (not (nil? goog/nodeGlobalRequire)))
 
-(defn host-env? [] (if (node-env?) :node :html))
+(defn worker-env? [] (and
+                      (nil? goog/global.document)
+                      (not (nil? (.-importScripts js/self)))))
+
+(defn host-env? [] (cond (node-env?)   :node
+                         (html-env?)   :html
+                         (worker-env?) :worker))
 
 (defn base-url-path [] (string/replace goog/basePath #"(.*)goog/" "$1"))
 


### PR DESCRIPTION
I'd like to use Figwheel in my WebWorkers, but currently it only handles node + html targets. This pull adds an environment predicate for WebWorkers (no document, self.importScripts is present), expands the webworker feature detection to allow websockets, and implements simple reloading via importScripts.

To use, the heads up display must be disabled in options, and the user must bootstrap the worker for closure `:optimizations :none` compilation manually with something like:

```javascript
CLOSURE_BASE_PATH = "compiled/worker_out/goog/"
/**
 * Imports a script using the Web Worker importScript API.
 *
 * @param {string} src The script source.
 * @return {boolean} True if the script was imported, false otherwise.
 */
this.CLOSURE_IMPORT_SCRIPT = (function(global) {
    return function(src) {
        global['importScripts'](src);
        return true;
    };
})(this);

BASE_PATH = "compiled/";
importScripts(CLOSURE_BASE_PATH + "base.js");
importScripts("compiled/worker.js");
goog.require('worker.core');
```

Thanks again for Figwheel, it has made me love the browser again!