### PR TITLE
Set text-align: left for the HUD

### DIFF
--- a/support/src/figwheel/client/heads_up.cljs
+++ b/support/src/figwheel/client/heads_up.cljs
@@ -68,6 +68,7 @@
                                 "opacity: 0.0;"
                                 "box-sizing: border-box;"
                                 "z-index: 10000;"
+                                "text-align: left;"
                                 ) })]
         (set! (.-onclick el) heads-up-onclick-handler)
         (set! (.-innerHTML el) cljs-logo-svg)


### PR DESCRIPTION
I'm using Figwheel on a page with `text-align: center` set for `body` (don't ask…). This makes the code block in the heads up display unreadable. It's easy to work around but I figured out Figwheel might as well deal with it out of the box, so here's a patch.

Workaround: put this into your CSS:

```css
#figwheel-heads-up-container { text-align: left; }
```