### PR TITLE
Add support for lein's `:managed-dependencies`

### DIFF
--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -19,6 +19,7 @@
                             :eval-in
                             :jvm-opts
                             :local-repo
+                            :managed-dependencies
                             :dependencies
                             :repositories
                             :mirrors


### PR DESCRIPTION
Prior to this commit, figwheel would error out on any projects
that were using lein's `:managed-dependencies` feature to
inject version numbers into the project.  This commit makes sure
that `:managed-dependencies` is one of the included keys selected
from the original project map, and allows projects that use this
key to run properly.