### PR TITLE
Add option to render index.html before 404

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -51,6 +51,7 @@
     ::server-port
     ::server-ip
     ::css-dirs
+    ::force-index
     ::ring-handler
     ::builds-to-start
     ::auto-clean
@@ -112,6 +113,15 @@ files. These files will be watched for changes and the figwheel client
 will attempt to reload them.
 
   :css-dirs [\"resources/public/css\"]")
+
+(def-key ::force-index       boolean?
+  "Typically, the figwheel server returns a 404 page if it cannot find
+a resource for a given path. With this option, you can force figwheel to
+attempt to return the index.html instead of the 404, which can be useful
+when using client-side routing libraries.
+Default: False
+
+  :force-index true")
 
 (def-key ::ring-handler      ::string-or-named
 


### PR DESCRIPTION
A common pattern for SPA sites is to use a client-side router (ex. [secretary](https://github.com/gf3/secretary)) and to direct all requests (except those to static resources) to `index.html`. 

The current built-in Figwheel server returns `index.html` for the server root, and static resources (for files from `resources/public/*`), but, when used with a client-side router, returns a 404 when a client-routed page is refreshed, forcing the dev to implement a server or use the `:ring-handler` option. 

On many SPA projects, I add a server *only* for the purpose of fixing this in development (in production, I just rewrite URLs w/ nginx, or with `.htaccess` rules).

**I think I would be useful to have an option to tell the Figwheel server to return the `index.html` file (if it exists)  instead of a 404.** For many projects, it would temporarily defer the need for a server, and for some projects, it will completely get rid of that need in development.

In this PR, I add a config option to Figwheel called `:force-index` (I'm open to suggestions for a better name),  which, when set to `true`, enables a catch-all route (which renders `index.html`) before the 404.