### PR TITLE
Don't blow up when `self` doesn't exist

### DIFF
--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -18,7 +18,8 @@
 
 (defn worker-env? [] (and
                       (nil? goog/global.document)
-                      (not (nil? (.-importScripts js/self)))))
+                      (exists? js/self)
+                      (exists? (.-importScripts js/self))))
 
 (defn host-env? [] (cond (node-env?)   :node
                          (html-env?)   :html


### PR DESCRIPTION
PR #498 added support for running in a web-worker, which is cool, but also implicitly assumed that `self` would always be defined - that's not the case on react-native. This fixes that by changing this to use `exists?`, and checking if `self` exists before trying to access properties on it