### PR TITLE
Add editorconfig file for consistent whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/example/project.clj
+++ b/example/project.clj
@@ -43,7 +43,7 @@
 
   :resource-paths ["resources" "other_resources"]
 
-  
+
   :cljsbuild {
               :builds {
                        :example {
@@ -69,9 +69,9 @@
                                             ;; :recompile-dependents true
                                             :optimizations :none}}
 
-                       
 
-                       
+
+
                        :example-prod {
                                       :source-paths ["src"]
                                       :compiler { :main example.core
@@ -90,7 +90,7 @@
                                            :target :nodejs
                                            :source-map true}}
                        :example-admin {
-                         :figwheel true              
+                         :figwheel true
                          :source-paths ["other_src" "src" #_"../support/src"]
                                        :compiler {
                                                   :main "example-admin.core"
@@ -133,7 +133,7 @@
              :server-port 3449 ;; default
              :css-dirs ["resources/public/css"]
              :open-file-command "emacsclient"
-             
+
              ;; :ring-handler example.server/handler
 
              ;; :repl false
@@ -172,5 +172,5 @@
 
              ;; :validate-config :warn-unknown-keys
              ;; :validate-interactive true
-             
+
              })

--- a/example/script/figwheel.clj
+++ b/example/script/figwheel.clj
@@ -9,7 +9,7 @@
    :all-builds
    [{ :id "example"
      :source-paths ["src"]
-     
+
      :figwheel { :websocket-host "localhost"
                 :on-jsload       "example.core/fig-reload"
                                         ; :debug true

--- a/examples/implicit-js-reloading/project.clj
+++ b/examples/implicit-js-reloading/project.clj
@@ -24,7 +24,7 @@
                            :output-to "resources/public/js/compiled/example.js"
                            :output-dir "resources/public/js/compiled/out"
                            :source-map-timestamp true}}
-               
+
                ;; JavaScript can also be the root of a cljs project!
                ;; This means that you can build a JavaScript project
                ;; in Figwheel. Again you need to follow the

--- a/examples/js-modules-reloading/project.clj
+++ b/examples/js-modules-reloading/project.clj
@@ -8,11 +8,11 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.459"]]
-  
+
   :plugins [[lein-figwheel "0.5.10-SNAPSHOT"]]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" :target-path]
-  
+
   :source-paths ["src"]
 
   :cljsbuild {:builds

--- a/examples/separate-server/project.clj
+++ b/examples/separate-server/project.clj
@@ -21,7 +21,7 @@
             ;; NOTE: lein-ring plugin allows you to start a server
             ;; with a simple `lein ring`
             ;; see --> https://github.com/weavejester/lein-ring
-            
+
             [lein-ring "0.10.0"]]
 
   ;; NOTE: configure lein-ring to serve your ring handler
@@ -66,7 +66,7 @@
   :aliases {"package" ["do" "clean"
                        ["cljsbuild" "once" "min"]
                        ["ring" "uberjar"]]}
-  
+
   ;; setting up nREPL for Figwheel and ClojureScript dev
   ;; Please see:
   ;; https://github.com/bhauman/lein-figwheel/wiki/Using-the-Figwheel-REPL-within-NRepl
@@ -78,7 +78,7 @@
                                   ;; see --> dev/user.clj
                                   [ring-server "0.4.0"]]
                    :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
-                   
+
                    ;; need to add dev source path here to get user.clj loaded
                    :source-paths ["src" "dev"]
                    ;; for CIDER

--- a/examples/using-ring-handler/project.clj
+++ b/examples/using-ring-handler/project.clj
@@ -51,7 +51,7 @@
                                   [figwheel-sidecar "0.5.10-SNAPSHOT"]
                                   [com.cemerick/piggieback "0.2.1"]]
                    :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
-                   
+
                    ;; need to add dev source path here to get user.clj loaded
                    :source-paths ["src" "dev"]
                    ;; for CIDER

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -15,5 +15,5 @@
                    :source-paths ["dev" "src"]
                    :aliases {"change-version" ["run" "-m" "figwheel-tasks.core" ":change-version"]
                              "install-all"    ["run" "-m" "figwheel-tasks.core" ":install-all"]}}}
-  
+
   :eval-in-leiningen true)

--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -4,7 +4,7 @@
    #_[clojure.pprint :as pp]
    [leiningen.core.eval :as leval]
    [leiningen.clean :as clean]
-   [leiningen.core.main :as main]   
+   [leiningen.core.main :as main]
    [clojure.java.io :as io]
    [clojure.set :refer [intersection]]
    [leiningen.figwheel.fuzzy :as fuz]
@@ -91,7 +91,7 @@
 (defn project-keys-affected-by-profile-mering [project]
   (when-let [{:keys [profiles]} (meta project)]
     (when (map? profiles)
-      (->> profiles 
+      (->> profiles
            vals
            (filter map?)
            (mapcat keys)
@@ -119,7 +119,7 @@
       false)))
 
 (comment
-  
+
   (def r (leiningen.core.project/read))
   #_(meta (raw-project-with-profile-meta r))
   (not=   (fuzzy-config-from-project (:without-profiles (meta r)))
@@ -230,7 +230,7 @@
             (str "---- Bad figwheel.edn File! ----\n"
                  "You have a malformed figwheel.edn file at the root of your\n"
                  "of your project directory.\n\n"
-                 
+
                  "While reading this file we encountered the following error:\n"
                  " --->  " (.getMessage e)
                  "\n\n"
@@ -315,7 +315,7 @@
          (filter map?)
          (keep (fn [x] (get-in x [:compiler :output-to])))
          (filter string?)
-         (keep #(.getParentFile (io/file %)))         
+         (keep #(.getParentFile (io/file %)))
          distinct
          (mapv #(.mkdirs %)))))
 
@@ -330,7 +330,7 @@
               :builds-to-start ["asdf"]
               :load-all-builds false
               }})
-  
+
   (source-paths-for-classpath (normalize-data test-project ["example"]))
   (figwheel-exec-body `())
 
@@ -360,7 +360,7 @@
 
 (defn report-if-bad-command [command]
   (when (and (command-like? command)
-             (not (known-commands command))) 
+             (not (known-commands command)))
     (println (str "Command Error: " (pr-str command)
                   " is not a known Figwheel command."))
     (println "  Known commands" (vec known-commands))
@@ -496,11 +496,11 @@ Commands:
   builds.
 
 :help
-  
+
   Prints this documentation
 
 Configuration:
-  
+
   Figwheel relies on a configuration that is found in the project.clj
   or in a figwheel.edn file in your project root. If a figwheel.edn is
   present any Figwheel configuration found in the project.clj will be

--- a/plugin/test/leiningen/figwheel_test.clj
+++ b/plugin/test/leiningen/figwheel_test.clj
@@ -98,7 +98,7 @@
           (= (->> v :cljsbuild :builds count)
              (count (:all-builds nd)))))))
 
-(defspec source-paths-for-class-path-arbi 
+(defspec source-paths-for-class-path-arbi
   iterations
   (prop/for-all
    [v (gen/map (gen/elements [:figwheel-options :all-builds :build-ids])

--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -31,7 +31,7 @@
    [strictly-specking-standalone "0.1.1"]]
 
   :clean-targets ^{:protect false} ["dev-resources/public/js" "target"]
-  
+
   :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.1"]]
                    :source-paths ["cljs_src" "src"]
                    :plugins [[lein-cljsbuild "1.1.3" :exclusions [[org.clojure/clojure]]]
@@ -67,5 +67,5 @@
                            :optimizations :simple}
                }]
               }
-  
+
   )

--- a/sidecar/src/figwheel_sidecar/build_middleware/clj_reloading.clj
+++ b/sidecar/src/figwheel_sidecar/build_middleware/clj_reloading.clj
@@ -67,7 +67,7 @@
   (cond
     (false? reload-clj-files) false
     (or (true? reload-clj-files)
-          (not (map? reload-clj-files))) 
+          (not (map? reload-clj-files)))
     {:cljc true :clj true}
     :else reload-clj-files))
 
@@ -105,7 +105,7 @@
                                      (:id build-config)
                                      { :msg-name :files-changed
                                       :files [{:file first-file :type :file}]}))))
-          
+
           (catch Throwable e
             (notify/handle-exceptions figwheel-server (assoc build-config :exception e))))
         (build-fn build-state)))))

--- a/sidecar/src/figwheel_sidecar/build_middleware/injection.clj
+++ b/sidecar/src/figwheel_sidecar/build_middleware/injection.clj
@@ -141,7 +141,7 @@
           (update-in [:compile-paths]
                      ;; using the connect script instead of inline code because of two prominent
                      ;; CLJS bugs
-                     ;; - another where the connection script isn't generated in a node env                     
+                     ;; - another where the connection script isn't generated in a node env
                      ;; https://github.com/bhauman/lein-figwheel/issues/474
                      ;; - one where analysis cache is invlidated
                      ;; https://github.com/bhauman/lein-figwheel/issues/489
@@ -170,10 +170,10 @@
 
 (defn require-connection-script-js [build]
   (let [node?     (when-let [target (get-in build [:build-options :target])]
-                    (= target :nodejs)) 
+                    (= target :nodejs))
         main?     (get-in build [:build-options :main])
         output-to (get-in build [:build-options :output-to])
-        munged-connect-script-ns (compiler/munge (figwheel-connect-ns-name build)) 
+        munged-connect-script-ns (compiler/munge (figwheel-connect-ns-name build))
         line (if (and main? (not node?))
                (str
                 (when (get-in build [:figwheel :devcards])

--- a/sidecar/src/figwheel_sidecar/build_middleware/notifications.clj
+++ b/sidecar/src/figwheel_sidecar/build_middleware/notifications.clj
@@ -48,7 +48,7 @@
 
 (defn file-changed?
   "Standard checksum to see if a file actually changed."
-  [{:keys [file-md5-atom]} filepath]  
+  [{:keys [file-md5-atom]} filepath]
   (when-let [file (io/file filepath)]
     (when (.exists file)
       (let [contents (slurp file)]

--- a/sidecar/src/figwheel_sidecar/cljs_utils/exception_parsing.clj
+++ b/sidecar/src/figwheel_sidecar/cljs_utils/exception_parsing.clj
@@ -6,7 +6,7 @@
    [clojure.stacktrace :as stack]
    [clojure.walk :refer [postwalk]]
    #_[clojure.pprint :refer [pprint]]
-   [strictly-specking-standalone.ansi-util :refer [color-text]]   
+   [strictly-specking-standalone.ansi-util :refer [color-text]]
    #_[cljs.build.api :as bapi]
    [figwheel-sidecar.utils :as utils]))
 
@@ -25,10 +25,10 @@
 (def serialize-edn-for-js-env (partial postwalk serialize-filter))
 
 (defn inspect-exception [ex]
-  (-> 
+  (->
    {:class (type ex)
     :message (.getMessage ex)
-    :data (ex-data ex)  
+    :data (ex-data ex)
     :cause (when (.getCause ex) (inspect-exception (.getCause ex)))}
    ;; adding exception to meta data because I don't want it serialize over the wire
    ;; and its only here as a fall back
@@ -200,7 +200,7 @@
                [[:error-in-code line (nth lines (dec line))]]
                [[:error-message nil
                  (breaker-line (nth lines (dec line))
-                               (when-not (= environment :repl) message) 
+                               (when-not (= environment :repl) message)
                                (if (= line 1)
                                  (+ (repl-prompt-indent
                                      environment
@@ -421,7 +421,7 @@
                       (fn [{:keys [class message]}]
                         (str "  " (when class (str (left-pad-string max-len class) " : "))
                              (color-text message :bold)))
-                      messages)))      
+                      messages)))
           "\n\n"))
    (when (pos? (count error-inline))
      (str  (format-error-inline error-inline)
@@ -518,7 +518,7 @@
     (catch Throwable e
       (inspect-exception e)
       #_(print-exception e)
-      #_(->> 
+      #_(->>
            exception-data->display-data
            formatted-exception-display-str
            #_println

--- a/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
+++ b/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
@@ -6,14 +6,14 @@
    [figwheel-sidecar.utils :as utils]
    [figwheel-sidecar.cljs-utils.exception-parsing :as cljs-ex]
    [strictly-specking-standalone.ansi-util :refer [with-color with-color-when color-text]]
-   
+
       ;; build hooks
    [figwheel-sidecar.build-middleware.injection :as injection]
    [figwheel-sidecar.build-middleware.notifications :as notifications]
    [figwheel-sidecar.build-middleware.clj-reloading :as clj-reloading]
    [figwheel-sidecar.build-middleware.javascript-reloading :as javascript-reloading]
    [figwheel-sidecar.build-middleware.stamp-and-clean :as stamp-and-clean]
-   
+
    [com.stuartsierra.component :as component]
    [cljs.closure]
    [cljs.build.api :as bapi]
@@ -50,7 +50,7 @@
                                "\" in " (time-elapsed started-at) ".")
                               :green))
         (catch Throwable e
-          (println (color-text (str 
+          (println (color-text (str
                                 "Failed to compile \""
                                 output-to
                                 "\" in " (time-elapsed started-at) ".")
@@ -89,13 +89,13 @@
       ;; the following two hooks have to be called before the notifications
       ;; a they modify the message on the way down
       clj-reloading/hook
-      javascript-reloading/hook      
+      javascript-reloading/hook
       color-output))
 
 (def figwheel-build-without-javascript-reloading
   (-> cljs-build
       injection/hook
-      notify-command-hook      
+      notify-command-hook
       figwheel-start-and-end-messages
       notifications/hook
       clj-reloading/hook
@@ -104,7 +104,7 @@
 (def figwheel-build-without-clj-reloading
   (-> cljs-build
       injection/hook
-      notify-command-hook      
+      notify-command-hook
       figwheel-start-and-end-messages
       notifications/hook
       javascript-reloading/hook
@@ -152,8 +152,8 @@
 
 (defn deadman-header-comment []
   "/* FIGWHEEL BAD COMPILE RECOVERY APPLICATION */
-/* NOT YOUR COMPILED CLOJURESCRIPT - TEMPORARY FIGWHEEL GENERATED PROGRAM 
- * This is only created in the case where the compile fails and you don't have a 
+/* NOT YOUR COMPILED CLOJURESCRIPT - TEMPORARY FIGWHEEL GENERATED PROGRAM
+ * This is only created in the case where the compile fails and you don't have a
  * generated output-to file.
  */")
 
@@ -241,7 +241,7 @@
         (flush)
         ;; Not the best but just to make sure there isn't a lingering figwheel connect script
         (injection/delete-connect-scripts! [build-config])
-        
+
         (let [cljs-build-fn (extract-cljs-build-fn this)]
           ;; build once before watching
           ;; tiny experience tweak
@@ -256,14 +256,14 @@
              ;; the order here is very very important
              ;; must think about the exception flow
              ;; exceptions must skip over code that needs the build to succeed
-             ;; also consider the messages that the user recieves 
+             ;; also consider the messages that the user recieves
              (-> cljs-build
                  injection/hook
                  notify-command-hook
                  figwheel-start-and-end-messages
                  catch-print-hook
                  open-urls-hook
-                 stamp-and-clean/hook                 
+                 stamp-and-clean/hook
                  color-output)
              cljs-build-fn) this)
           (assoc this

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -15,7 +15,7 @@
    [ring.util.mime-type :as mime]
    [ring.middleware.cors :as cors]
    [org.httpkit.server :refer [run-server with-channel on-close on-receive send! open?]]
-   
+
    [com.stuartsierra.component :as component]))
 
 (defprotocol ChannelServer
@@ -68,7 +68,7 @@
           (println "Figwheel: there was a problem running the open file command - "
                    command)
           (println (.getMessage e))))
-      (println "Figwheel: Can't open " (pr-str (vals (select-keys msg [:file-name :file-line :file-column]))) 
+      (println "Figwheel: Can't open " (pr-str (vals (select-keys msg [:file-name :file-line :file-column])))
                "No :open-file-command supplied in the config."))))
 
 ;; should make this extendable with multi-method
@@ -108,19 +108,19 @@
            (<!! (timeout compile-wait-time))
            (when (open? wschannel)
              (send! wschannel (prn-str msg)))))))
-    
+
     (on-close wschannel
               (fn [status]
                 (update-connection-count connection-count desired-build-id dec)
                 (remove-watch file-change-atom watch-key)
                 #_(println "Figwheel: client disconnected " status)))
-    
+
     (on-receive wschannel
                 (fn [data] (#'handle-client-msg server-state data
                             )))
 
     ;; Keep alive!!
-    ;; 
+    ;;
     (go-loop []
       (<! (timeout 5000))
       (when (open? wschannel)
@@ -209,14 +209,14 @@
      (fn [_]
        (response/not-found
         "<div><h1>Figwheel Server: Resource not found</h1><h3><em>Keep on figwheelin'</em></h3></div>"))
-     
+
      ;; users handler goes last
      (possible-endpoint resolved-ring-handler)
-     
+
      (handle-static-resources http-server-root)
      (handle-index            http-server-root)
      (handle-figwheel-websocket server-state)
-     
+
      ;; adding cors to support @font-face which has a strange cors error
      ;; super promiscuous please don't uses figwheel as a production server :)
      (cors/wrap-cors
@@ -250,7 +250,7 @@
         (assoc :callback-name callback-name)))
     msg-data))
 
-;; remove resource paths here 
+;; remove resource paths here
 (defn create-initial-state [{:keys [unique-id
                                     http-server-root
                                     server-port
@@ -266,7 +266,7 @@
        {
         ;; seems like this id should be different for every
         ;; server restart thus forcing the client to reload
-        :unique-id (or unique-id (.getCanonicalPath (io/file "."))) 
+        :unique-id (or unique-id (.getCanonicalPath (io/file ".")))
         :http-server-root (or http-server-root "public")
         :server-port (or server-port 3449)
         :server-ip (or server-ip "0.0.0.0")
@@ -274,10 +274,10 @@
         ;; TODO handle this better
         :resolved-ring-handler (or resolved-ring-handler
                                    (utils/require-resolve-handler ring-handler))
-        
+
         :open-file-command open-file-command
         :compile-wait-time (or compile-wait-time 10)
-        
+
         :file-md5-atom (atom {})
 
         :ansi-color-output (if (false? ansi-color-output) false true)
@@ -343,7 +343,7 @@
 (defn config-options [figwheel-server]
   (-actual figwheel-server))
 
-;; setup server for overall system 
+;; setup server for overall system
 
 (defn ensure-array-map [all-builds]
   (into (array-map)
@@ -371,10 +371,10 @@
           config-data)
         all-builds (map butils/add-compiler-env (config/prep-builds* all-builds))
         all-builds (ensure-array-map all-builds)
-        
+
         initial-state       (create-initial-state figwheel-options)
         figwheel-opts (assoc initial-state
-                             :builds all-builds       
+                             :builds all-builds
                              :log-writer    (extract-log-writer figwheel-options)
                              :cljs-build-fn (extract-cljs-build-fn figwheel-options))]
     (map->FigwheelServer figwheel-opts)))

--- a/sidecar/src/figwheel_sidecar/components/nrepl_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/nrepl_server.clj
@@ -53,7 +53,7 @@
   Options:
   :nrepl-port   the port to start the server on; must exist or the server wont start
   :nrepl-host   an optional network host to open the port on
-  :nrepl-middleware a optional list of nREPL middleware to include 
+  :nrepl-middleware a optional list of nREPL middleware to include
 
   This function will attempt to require/load the
   cemerick.piggieback/wrap-cljs-repl middleware which is needed to

--- a/sidecar/src/figwheel_sidecar/config.clj
+++ b/sidecar/src/figwheel_sidecar/config.clj
@@ -9,7 +9,7 @@
    [simple-lein-profile-merge.core :as lm]
    [figwheel-sidecar.utils.fuzzy :as fuz]
    [strictly-specking-standalone.ansi-util :refer [with-color-when color-text]]
-      
+
    [figwheel-sidecar.utils :as utils]
    [strictly-specking-standalone.core :as speck]
    [figwheel-sidecar.schemas.config :as config-spec]
@@ -123,7 +123,7 @@
     (vec (map (fn [[k v]] (assoc v :id (name k))) builds))
     builds))
 
-(defn narrow-builds* 
+(defn narrow-builds*
   "Filters builds to the chosen build-ids or if no build-ids specified returns the first
    build with optimizations set to none."
   [builds build-ids]
@@ -172,7 +172,7 @@
 (defn normalize-dir
   "If directory ends with '/' then truncate the trailing forward slash."
   [dir]
-  (if (and dir (< 1 (count dir)) (re-matches #".*\/$" dir)) 
+  (if (and dir (< 1 (count dir)) (re-matches #".*\/$" dir))
     (subs dir 0 (dec (count dir)))
     dir))
 
@@ -201,7 +201,7 @@
 
 (comment
   (default-optimizations-to-none {:optimizations :simple})
-  
+
   (sane-output-to-dir {:output-dir "yes" })
 
   (sane-output-to-dir {:output-to "yes.js"})
@@ -275,10 +275,10 @@
   (cond-> url
     (.contains url "[[server-hostname]]")
     (string/replace "[[server-hostname]]" (.getHostName (java.net.InetAddress/getLocalHost)))
-    
+
     (.contains url "[[server-ip]]")
     (string/replace "[[server-ip]]"       (.getHostAddress (java.net.InetAddress/getLocalHost)))
-    
+
     (.contains url "[[server-port]]")
     (string/replace "[[server-port]]"     (str server-port))))
 
@@ -322,13 +322,13 @@
                                     :id "dev"
                                     :figwheel {:foo 1
                                                :websocket-host :server-ip}})
-  
+
   (update-figwheel-connect-options {:server-port 5555}
                                    {:yeah 6
                                     :id "dev"
                                     :figwheel {:foo 1
                                                :websocket-host :server-hostname}})
-  
+
   )
 
 (comment
@@ -394,7 +394,7 @@
 ;; validation
 
 ;; TODO add :validate-interactive option
-;; TODO add :validate-level option   
+;; TODO add :validate-level option
 
 ;; TODO move to standalone
 
@@ -446,13 +446,13 @@
   (def xxx (->config-data (->lein-project-config-source)))
 
   (lein-project-spec (:data xxx))
-  
+
   (all-builds xxx)
-  
+
   (validate-project-config-data xxx)
   (speck/explain (lein-project-spec (:data xxx))
                  (fuz/fuzzy-select-keys (:data xxx) [:cljsbuild :figwheel]))
-  
+
   (let [x (fuz/fuzzy-select-keys (:data xxx) [:cljsbuild :figwheel])
         x (-> x (:cljsbuild x))]
     (validate-figwheel-edn-config-data {:data x})
@@ -554,7 +554,7 @@
 (comment
   (->config-data (->lein-project-config-source))
   (->config-data (->figwheel-config-source nil "/Users/bhauman/workspace/lein-figwheel/example/figwheel.edn"))
-  
+
   )
 
 
@@ -590,7 +590,7 @@
                      "Or keys like: " (pr-str internal-keys))
                     {:reason :not-a-configuration-map
                      :config-data data}))))
-    (throw (ex-info "The configuration data provided is not a Map" 
+    (throw (ex-info "The configuration data provided is not a Map"
                     {:reason :configuration-not-a-map
                      :config-data data})) ))
 

--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -1,6 +1,6 @@
 (ns figwheel-sidecar.repl
   (:require
-   [cljs.analyzer :as ana]   
+   [cljs.analyzer :as ana]
    [cljs.env :as env]
    [cljs.repl]
    [cljs.stacktrace]
@@ -13,7 +13,7 @@
 
    [figwheel-sidecar.cljs-utils.exception-parsing :as cljs-ex]
    [figwheel-sidecar.components.figwheel-server :as server]
-   
+
    [figwheel-sidecar.config :as config]
    [strictly-specking-standalone.ansi-util :refer [with-color-when color]]   )
   (:import [clojure.lang IExceptionInfo]))
@@ -165,8 +165,8 @@
     (catch Exception e
       (println "!!!" (.getMessage e))
       (let [message "Failed to launch Figwheel CLJS REPL: nREPL connection found but unable to load piggieback.
-This is commonly caused by 
- A) not providing piggieback as a dependency and/or 
+This is commonly caused by
+ A) not providing piggieback as a dependency and/or
  B) not adding piggieback middleware into your nrepl middleware chain.
 
 example profile.clj code:
@@ -308,6 +308,6 @@ This can cause confusion when your are not using Cider."]
       :default)
     (apply cljs-repl-env args)))
 
-;; deprecated 
+;; deprecated
 (defn get-project-cljs-builds []
   (-> (config/fetch-config) :data :all-builds))

--- a/sidecar/src/figwheel_sidecar/repl_api.clj
+++ b/sidecar/src/figwheel_sidecar/repl_api.clj
@@ -233,7 +233,7 @@ the first default id)."
           unknown-ids (set/difference
                        (set build-ids)
                        (set (map :id all-builds)))]
-      
+
       (when (empty? builds)
         (println "Figwheel: Didn't find any the supplied build ids in the configuration.")
         (println "Unknown build ids: " (pr-str (vec unknown-ids)))
@@ -255,5 +255,5 @@ the first default id)."
   (launch-from-lein (:data proj) ["dev"])
 
   (launch-from-lein (:data proj) ["example-prod"])
-  
+
   )

--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -176,7 +176,7 @@ code in nodejs.
 When you set :infer-externs true you will get a new file in
 your :output-dir named inferred_externs.js. When you do an advanced
 build, this externs file will be used.
-  
+
 You must add type hints to your code as such:
 
   (set! *warn-on-infer* true)
@@ -803,12 +803,12 @@ See the Closure Compiler Warning wiki for detailed descriptions.")
    (attach-reason  ":source-map must be a string? when :optimizations is not :none"
                    (fn [{:keys [source-map optimizations] :as cmpl}]
                      (not (and
-                           (contains? cmpl :source-map)                           
+                           (contains? cmpl :source-map)
                            (not (string? source-map))
                            (not (opt-none? optimizations)))))
                    :focus-path [:source-map])
 
-   
+
    (strict-keys
     :opt-un
     [::main

--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -63,11 +63,11 @@
     ::nrepl-host
     ::nrepl-middleware
     ::validate-config
-    ::validate-interactive    
+    ::validate-interactive
     ::load-all-builds
     ::ansi-color-output
     ::builds
-    ::reload-clj-files    
+    ::reload-clj-files
     ::hawk-options])
   "A Map of options that determine the behavior of the Figwheel system.
 
@@ -163,7 +163,7 @@ when you invoke lein figwheel without arguments.
 (def-key ::auto-clean boolean?
   "Figwheel detects whether dependencies have changed and
 automatically deletes compiled assets to prevent compilation
-inconsistencies.  
+inconsistencies.
 
 You can set :auto-clean flase to disable this behavior.
 Default: true
@@ -180,7 +180,7 @@ Default: \"figwheel_server.log\"
 
   :server-logfile \"tmp/figwheel_server.log\"
 
-or 
+or
 
   :server-logfile false")
 
@@ -198,7 +198,7 @@ The add this script in your config:
   :open-file-command \"myfile-opener\"
 
 But thats not the best example because Figwheel handles 'emacsclient'
-as a special case so as long as 'emacsclient' is on the shell path you can 
+as a special case so as long as 'emacsclient' is on the shell path you can
 simply do:
 
   :open-file-command \"emacsclient\"
@@ -373,7 +373,7 @@ Or you can specify which suffixes will cause the reloading
 ;; it also can be found at the top level of a figwheel.edn file
 
 (def-key ::builds
-  (s/or                
+  (s/or
    :builds-vector (s/every ::build-config-require-id :min-count 1 :into [] :kind sequential?)
    :builds-map  (s/every-kv ::string-or-named ::build-config
                             :kind map?
@@ -465,7 +465,7 @@ Or you can specify which suffixes will cause the reloading
         e (first (ssp/prepare-errors exd x nil))]
     (ep/pprint-inline-message e)
     (ssp/dev-print exd x nil)
-    
+
     )
 
 )
@@ -503,7 +503,7 @@ example.core namespace, the source path to this file is \"src\"
 
   :source-paths [\"src\"]
 
-Advanced: 
+Advanced:
 
 This value represents three concrete things:
 
@@ -528,7 +528,7 @@ with :compile-paths.
 
 (def-key ::watch-paths (s/every non-blank-string? :into [] :kind sequential?)
   "A vector of paths to directories that you want figwheel to watch
-for changes. 
+for changes.
 
 The default value is the contents of :source-paths
 
@@ -537,7 +537,7 @@ These paths should be relative from the root of the project.
   :watch-paths [\"src\"]")
 
 (def-key ::compile-paths (s/every non-blank-string? :into [] :kind sequential?)
-  "A vector of paths to the directories of cljs source files that you want compiled. 
+  "A vector of paths to the directories of cljs source files that you want compiled.
 
 The default value is the contents of :source-paths
 
@@ -582,8 +582,8 @@ want the figwheel client code to be injected into the build.
 Or
 
   :figwheel {
-    :on-jsload \"example.core/on-reload\" 
-  } 
+    :on-jsload \"example.core/on-reload\"
+  }
 ")
 
 (def-key ::compiler ::cljs-opt/compiler-options
@@ -735,7 +735,7 @@ immediately jumping to the error in the file when a compile error or
 compile warning occurs.
 
 Default: false
-  
+
   :auto-jump-to-source-on-error true")
 
 (def-key ::load-warninged-code  boolean?
@@ -839,7 +839,7 @@ Default: nil (disabled)
          "The only known opt' :none build configs are " (pr-str (known-build-ids proj)))))
     builds-to-start-ids-must-be-in-builds
     :focus-path (fn [project]
-                  (if-let [idx (when-let [ky 
+                  (if-let [idx (when-let [ky
                                           (first
                                            (get-builds-to-start-not-in-build-ids project))]
                                  (.indexOf (vec (-> project :figwheel :builds-to-start))
@@ -909,7 +909,7 @@ Default: nil (disabled)
         e (first (ssp/prepare-errors exd x nil))]
     (ep/pprint-inline-message e)
     (ssp/dev-print exd x nil)
-    
+
     )
 
 )
@@ -968,7 +968,7 @@ Default: nil (disabled)
   ;; wait for merge to not propogate conformed values
   (s/and
    map?
-   #(contains? % :builds)   
+   #(contains? % :builds)
    must-have-one-opt-none-build-spec
    :figwheel.lein-project/figwheel))
 
@@ -1019,7 +1019,7 @@ Example figwheel.edn file
 
 
 
-                           
+
                                  :compiler { :main 'example.core
                                              :asset-path "js/out"
                                              :output-to "resources/public/js/example.js"
@@ -1060,7 +1060,7 @@ Example figwheel.edn file
                                                           "http://localhost:3449/index.html"]
                                   :debug true
                                   }
-                           
+
                                  :compiler { :main 'example.core
                                             :asset-path "js/out"
                                             :output-to "resources/public/js/example.js"
@@ -1087,7 +1087,7 @@ Example figwheel.edn file
                                                           "http://localhost:3449/index.html"]
                                   :debug true
                                   }
-                           
+
                                  :compiler { :main 'example.core
                                             :asset-path "js/out"
                                             :output-to "resources/public/js/example.js"
@@ -1098,7 +1098,7 @@ Example figwheel.edn file
                                                             :provides ["wowzacore"]}]
                                             ;; :recompile-dependents true
                                             :optimizations :none}}
-                           
+
 
                                 { :id "example"
                                  :source-paths ["src" "dev" "tests" "../support/src"]
@@ -1130,12 +1130,12 @@ Example figwheel.edn file
                                    {})
                    {}
                    nil)
-  
+
   (first (ssp/prepare-errors (s/explain-data ::lein-project-with-cljsbuild
                                             test-data)
                             test-data
                             nil))
- 
+
   )
 
 

--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -3,7 +3,7 @@
    [figwheel-sidecar.utils :as utils]
    [figwheel-sidecar.build-utils :as butils]
    [figwheel-sidecar.config :as config]
-   [figwheel-sidecar.repl :as frepl]   
+   [figwheel-sidecar.repl :as frepl]
 
    [figwheel-sidecar.components.nrepl-server    :as nrepl-comp]
    [figwheel-sidecar.components.css-watcher     :as css-watch]
@@ -13,7 +13,7 @@
    [strictly-specking-standalone.ansi-util :refer [with-color-when color-text]]
    [com.stuartsierra.component :as component]
 
-   [clojure.pprint :as p]   
+   [clojure.pprint :as p]
    [clojure.java.io :as io]
    [clojure.set :refer [difference union intersection]]
    [clojure.string :as string]))
@@ -120,7 +120,7 @@
       this))
   (stop [this]
     (if (:system-running this)
-      (do 
+      (do
         (swap! system component/stop)
         (assoc this :system-running false))
       this))
@@ -156,10 +156,10 @@
   If you only have a few components to add to this system then you can
   assoc them onto the created system before you start like so.
 
-  (def my-system 
+  (def my-system
     (assoc (create-figwheel-system (config/fetch-config))
-           :html-reload 
-           (component/using 
+           :html-reload
+           (component/using
              (html-reloader {:watch-paths [\"resources/public\"]})
              [:figwheel-system])
            :web-server (my-webserver-component)))"
@@ -225,7 +225,7 @@
 ;; figwheel system control function helpers
 
 (defn build-diff
-  "Makes sure that the autobuilds in the system match the build-ids provided" 
+  "Makes sure that the autobuilds in the system match the build-ids provided"
   [system ids]
   (let [ids (set (map id->key ids))
         build-keys (all-build-keys system)]
@@ -301,7 +301,7 @@
 (defn- clean-build
   "Deletes compiled assets for given id."
   [system id]
-  (if-let [build-options 
+  (if-let [build-options
            (get-in system [:figwheel-server :builds (name id) :build-options])]
     (do
       (println "Figwheel: Cleaning build -" id)
@@ -330,7 +330,7 @@
                       (map key->id
                            (ids-or-all-build-keys system running-ids))
                       running-ids)]
-    (if-let [ids (not-empty process-ids)] 
+    (if-let [ids (not-empty process-ids)]
       (stop-and-start-watchers
        system ids
        #(reduce clean-build % ids))
@@ -375,7 +375,7 @@
           (println (.getMessage e))
           {})
         (throw e)))))
-  
+
 (defn get-project-builds []
   (into (array-map)
         (map
@@ -459,9 +459,9 @@
   {'start-autobuild (make-special-fn (system-setter start-autobuild system))
    'stop-autobuild  (make-special-fn (system-setter stop-autobuild system))
    'switch-to-build (make-special-fn (system-setter switch-to-build system))
-   'clean-builds    (make-special-fn (system-setter clean-builds system)) 
+   'clean-builds    (make-special-fn (system-setter clean-builds system))
    'build-once      (make-special-fn (system-setter build-once system))
-   
+
    'reset-autobuild (make-special-fn (system-setter
                                             (fn [sys _] (reset-autobuild sys))
                                             system))
@@ -473,7 +473,7 @@
                                             (fn [sys _] (fig-status sys))
                                             system))})
 
-(def repl-function-docs 
+(def repl-function-docs
   "Figwheel Controls:
           (stop-autobuild)                ;; stops Figwheel autobuilder
           (start-autobuild [id ...])      ;; starts autobuilder focused on optional ids
@@ -532,7 +532,7 @@
         (let [res (read-line)]
           (cond
             (nil? res) false
-            (choices res) res          
+            (choices res) res
             (= res "quit") false
             (= res "exit") false
             :else
@@ -592,7 +592,7 @@
                    start-build-id
                    (initial-repl-focus-build-id @system))]
      (if (frepl/in-nrepl-env?)
-       (figwheel-cljs-repl* system build-id repl-options) 
+       (figwheel-cljs-repl* system build-id repl-options)
        (build-switching-cljs-repl* system build-id repl-options)))))
 
 ;; takes a FigwheelSystem
@@ -663,7 +663,7 @@
 
         (map? (first args))
         [(first args) (not-empty (rest args))]
-        
+
         ((some-fn string? symbol? keyword?) (first args))
         [(config/fetch-config) args]
         :else
@@ -681,7 +681,7 @@
         (-> config-options
             config/->config-source
             config/config-source->prepped-figwheel-internal
-            config/adjust-to-internal-configuration-representation            
+            config/adjust-to-internal-configuration-representation
             :data)
         internal-config-data (if (not-empty build-ids)
                                (do
@@ -708,19 +708,19 @@
   autobuilding.  If these ids aren't available in the builds specified
   in the found configuration this function will throw an error.
 
-(start-figwheel! 
+(start-figwheel!
   ;; using the configuration shape of figwheel.edn
   {:server-port 5000
    :builds [{:id ...}]}
 
-(start-figwheel! 
+(start-figwheel!
   ;; using the configuration shape of figwheel.edn
   {:server-port 5000
    :builds (figwheel-sidecar.config/get-project-builds)
    :builds-to-start [\"example\"]})
 
-(start-figwheel! 
- ;; using the soon to be deprecated legacy configuration shape 
+(start-figwheel!
+ ;; using the soon to be deprecated legacy configuration shape
  {:figwheel-options { :server-port 4000 }
   :all-builds [{:id ...}]
   :build-ids [\"example\"]})

--- a/sidecar/src/figwheel_sidecar/utils.clj
+++ b/sidecar/src/figwheel_sidecar/utils.clj
@@ -81,7 +81,7 @@
   [p] (string/replace p  "\\" "/"))
 
 (let [root (norm-path (.getCanonicalPath (io/file ".")))]
-  (defn remove-root-path 
+  (defn remove-root-path
     "relativize to the local root just in case we have an absolute path"
     [path]
     (string/replace-first (norm-path path) (str root "/") "")))

--- a/sidecar/src/figwheel_sidecar/utils/fuzzy.clj
+++ b/sidecar/src/figwheel_sidecar/utils/fuzzy.clj
@@ -92,10 +92,10 @@
   (into {} (map #(let [[_ v] (get-keylike % m)] [% v]) kys)))
 
 (comment
-  
+
   (metrics/levenshtein "GSFD" "GFSD")
-  
+
   (ky-distance :GFSD :GSFD)
-  
+
   (ky-distance :figwheel :figwheeler)
   )

--- a/sidecar/src/figwheel_sidecar/watching.clj
+++ b/sidecar/src/figwheel_sidecar/watching.clj
@@ -40,7 +40,7 @@
 (defn watch! [hawk-options source-paths callback]
   (let [hawk-options (default-hawk-options hawk-options)
         throttle-chan (chan)
-        
+
         {:keys [files dirs]} (files-and-dirs source-paths)
         individual-file-map   (single-files files)
         canonical-source-dirs (set (map #(.getCanonicalPath %) dirs))
@@ -48,7 +48,7 @@
         source-paths (distinct
                       (concat (map str dirs)
                               (map #(.getParent %) files)))
-        
+
         valid-file?   (fn [file]
                         (and file
                              (.isFile file)
@@ -74,14 +74,14 @@
                    :filter hawk/file?
                    :handler (fn [ctx e]
                               (put! throttle-chan e))}])]
-    
+
     (go-loop []
       (when-let [v (<! throttle-chan)]
         (let [files (<! (take-until-timeout throttle-chan))]
           (when-let [result-files (not-empty (distinct (filter valid-file? (map :file (cons v files)))))]
             (callback result-files)))
         (recur)))
-    
+
     {:watcher watcher
      :throttle-chan throttle-chan}))
 


### PR DESCRIPTION
This PR adds an editorconfig file which provides consistent formatting rules for all editors to follow. In particular it ensures there is always a final newline in a file and trailing whitespace is trimmed.

The existing repo was updated with the [eclint](https://www.npmjs.com/package/eclint) tool.