### PR TITLE
Add support for reloading in React Native environment

### DIFF
--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -3,7 +3,7 @@
    [figwheel.client.utils :as utils :refer-macros [dev-assert]]
    [goog.Uri :as guri]
    [goog.string]
-   [goog.object :as gobj]   
+   [goog.object :as gobj]
    [goog.net.jsloader :as loader]
    [goog.string :as gstring]
    [clojure.string :as string]
@@ -108,7 +108,7 @@
 (defn setup-ns->dependents!
   "This reverses the goog.dependencies_.requires for looking up ns-dependents."
   []
-  (let [requires (gobj/filter js/goog.dependencies_.requires 
+  (let [requires (gobj/filter js/goog.dependencies_.requires
                               (fn [v k o] (gstring/startsWith k "../")))]
     (gobj/forEach
      requires
@@ -200,7 +200,7 @@
           (fn [& args]
             (apply addDependency args)
             (apply (.-addDependency_figwheel_backup_ js/goog) args)))
-    
+
     (goog/constructNamespace_ "cljs.user")
     ;; we must reuse Closure library dev time dependency management, under namespace
     ;; reload scenarios we simply delete entries from the correct
@@ -233,12 +233,12 @@
                         (utils/log :error (.-stack e))
                         false))))))
 
-    :html (fn [request-url callback]
-            (dev-assert (string? request-url) (not (nil? callback)))
-            (let [deferred (loader/load (add-cache-buster request-url)
-                                        #js { :cleanupWhenDone true })]
-              (.addCallback deferred #(apply callback [true]))
-              (.addErrback deferred #(apply callback [false]))))
+    :html-or-RN (fn [request-url callback]
+                  (dev-assert (string? request-url) (not (nil? callback)))
+                  (let [deferred (loader/load (add-cache-buster request-url)
+                                              #js {:cleanupWhenDone true})]
+                    (.addCallback deferred #(apply callback [true]))
+                    (.addErrback deferred #(apply callback [false]))))
     :worker (fn [request-url callback]
               (dev-assert (string? request-url) (not (nil? callback)))
               (callback (try
@@ -411,7 +411,7 @@
         (utils/log :debug "Figwheel: loaded these dependencies")
         (utils/log (pr-str (map (fn [{:keys [request-url]}]
                                   (string/replace request-url goog/basePath ""))
-                                (reverse dependencies-that-loaded)))))      
+                                (reverse dependencies-that-loaded)))))
       (when (not-empty res)
         (utils/log :debug "Figwheel: loaded these files")
         (utils/log (pr-str (map (fn [{:keys [namespace file]}]
@@ -421,7 +421,7 @@
         (js/setTimeout #(do
                           (on-jsload-custom-event res)
                           (apply on-jsload [res])) 10))
-      
+
       (when (not-empty files-not-loaded)
         (utils/log :debug "Figwheel: NOT loading these files ")
         (let [{:keys [figwheel-no-load not-required]}
@@ -446,10 +446,10 @@
          (.getElementsByTagName js/document "link")))
 
 (defn truncate-url [url]
-  (-> (first (string/split url #"\?")) 
+  (-> (first (string/split url #"\?"))
       (string/replace-first (str (.-protocol js/location) "//") "")
       (string/replace-first ".*://" "")
-      (string/replace-first #"^//" "")         
+      (string/replace-first #"^//" "")
       (string/replace-first #"[^\/]*" "")))
 
 (defn matches-file?

--- a/support/src/figwheel/client/socket.cljs
+++ b/support/src/figwheel/client/socket.cljs
@@ -5,7 +5,8 @@
 
 (defn get-websocket-imp []
   (cond
-    (utils/html-env?) (aget js/window "WebSocket")
+    (or (utils/html-env?)
+        (utils/react-native-env?)) (aget js/window "WebSocket")
     (utils/node-env?) (try (js/require "ws")
                            (catch js/Error e
                              nil))
@@ -75,7 +76,7 @@
                                    (let [retried-count (or retried-count 0)]
                                      (utils/debug-prn "Figwheel: socket closed or failed to open")
                                      (when (> retry-count retried-count)
-                                       (js/setTimeout 
+                                       (js/setTimeout
                                         (fn []
                                           (open
                                            (assoc opts :retried-count (inc retried-count))))

--- a/support/src/figwheel/client/socket.cljs
+++ b/support/src/figwheel/client/socket.cljs
@@ -5,8 +5,7 @@
 
 (defn get-websocket-imp []
   (cond
-    (or (utils/html-env?)
-        (utils/react-native-env?)) (aget js/window "WebSocket")
+    (utils/html-or-react-native-env?) (aget js/window "WebSocket")
     (utils/node-env?) (try (js/require "ws")
                            (catch js/Error e
                              nil))

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -14,6 +14,8 @@
 
 (defn html-env? [] (not (nil? goog/global.document)))
 
+(defn react-native-env? [] (= goog/global.navigator.product "ReactNative"))
+
 (defn node-env? [] (not (nil? goog/nodeGlobalRequire)))
 
 (defn worker-env? [] (and
@@ -21,9 +23,10 @@
                       (exists? js/self)
                       (exists? (.-importScripts js/self))))
 
-(defn host-env? [] (cond (node-env?)   :node
-                         (html-env?)   :html
-                         (worker-env?) :worker))
+(defn host-env? [] (cond (node-env?)              :node
+                         (or (html-env?)
+                             (react-native-env?)) :html-or-RN
+                         (worker-env?)            :worker))
 
 (defn base-url-path [] (string/replace goog/basePath #"(.*)goog/" "$1"))
 
@@ -56,7 +59,7 @@
 (defn log
   ([x] (log :info x))
   ([level arg]
-   (let [f (condp = (if (html-env?) level :info)
+   (let [f (condp = (if (or (html-env?) (react-native-env?)) level :info)
             :warn  #(.warn js/console %)
             :debug #(.debug js/console %)
             :error #(.error js/console %)

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -18,15 +18,18 @@
 
 (defn node-env? [] (not (nil? goog/nodeGlobalRequire)))
 
+(defn html-or-react-native-env? []
+  (or (html-env?) (react-native-env?)))
+
 (defn worker-env? [] (and
                       (nil? goog/global.document)
                       (exists? js/self)
                       (exists? (.-importScripts js/self))))
 
-(defn host-env? [] (cond (node-env?)              :node
-                         (or (html-env?)
-                             (react-native-env?)) :html-or-RN
-                         (worker-env?)            :worker))
+(defn host-env? [] (cond (node-env?)         :node
+                         (html-env?)         :html
+                         (react-native-env?) :react-native
+                         (worker-env?)       :worker))
 
 (defn base-url-path [] (string/replace goog/basePath #"(.*)goog/" "$1"))
 
@@ -59,7 +62,7 @@
 (defn log
   ([x] (log :info x))
   ([level arg]
-   (let [f (condp = (if (or (html-env?) (react-native-env?)) level :info)
+   (let [f (condp = (if (html-or-react-native-env?) level :info)
             :warn  #(.warn js/console %)
             :debug #(.debug js/console %)
             :error #(.error js/console %)

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -14,7 +14,8 @@
 
 (defn html-env? [] (not (nil? goog/global.document)))
 
-(defn react-native-env? [] (= goog/global.navigator.product "ReactNative"))
+(defn react-native-env? [] (and (exists? goog/global.navigator)
+                                (= goog/global.navigator.product "ReactNative")))
 
 (defn node-env? [] (not (nil? goog/nodeGlobalRequire)))
 


### PR DESCRIPTION
Currently `lein-figwheel >= 0.5.9` crashes with `Reload not defined for this platform` error message in React Native applications ([re-natal](https://github.com/drapanjanas/re-natal)). This commit fixes the problem.