### PR TITLE
Fix libs versions on examples/node-example/project.clj

### DIFF
--- a/examples/node-example/project.clj
+++ b/examples/node-example/project.clj
@@ -9,7 +9,7 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.clojure/clojurescript "1.9.229"]]
 
-  :plugins [[lein-figwheel "0.5.4-7"]]
+  :plugins [[lein-figwheel "0.5.9"]]
 
   :source-paths ["src"]
 
@@ -28,7 +28,7 @@
                            ;; !!! need to set the target to :nodejs !!!
                            :target :nodejs}}]}
 
-  :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.4-7"]
+  :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.9"]
                                   [com.cemerick/piggieback "0.2.1"]]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}
 )

--- a/examples/node-example/project.clj
+++ b/examples/node-example/project.clj
@@ -9,7 +9,7 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.clojure/clojurescript "1.9.229"]]
 
-  :plugins [[lein-figwheel "0.5.10-SNAPSHOT"]]
+  :plugins [[lein-figwheel "0.5.4-7"]]
 
   :source-paths ["src"]
 
@@ -28,7 +28,7 @@
                            ;; !!! need to set the target to :nodejs !!!
                            :target :nodejs}}]}
 
-  :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.10-SNAPSHOT"]
+  :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.4-7"]
                                   [com.cemerick/piggieback "0.2.1"]]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}
 )


### PR DESCRIPTION
Tested with 
```
$ lein -v                                                                                                                                                              
Leiningen 2.7.1 on Java 1.8.0_66 Java HotSpot(TM) 64-Bit Server VM
$ node -v                                                                                                                                                              
v7.6.0
```