### PR TITLE
Avoid throwing when reloading foreign Javascript in boot

### DIFF
--- a/sidecar/src/figwheel_sidecar/build_middleware/javascript_reloading.clj
+++ b/sidecar/src/figwheel_sidecar/build_middleware/javascript_reloading.clj
@@ -2,18 +2,54 @@
   (:require
    [clojure.java.io :as io]
    [cljs.build.api :as bapi]
-   [figwheel-sidecar.utils :as utils]
-   [clojure.pprint :as pp]))
+   [figwheel-sidecar.utils :as utils])
+  (:import [java.nio.file Path]))
 
 ;; live javascript reloading
+
+;; just in case we get a URL or some such let's change it to a string first
+
+(defn relativize-local
+  "Create a relative path for the input and return the java.io.File.
+
+  The 1-arity function use the current working directory as path to
+  relativize against."
+  ([^Path path]
+   (relativize-local (.toPath (utils/cwd)) path))
+  ([^Path other-path ^Path path]
+   ;; Where this path and the given path do not have a root component, then a
+   ;; relative path can be constructed. A relative path cannot be constructed
+   ;; if only one of the paths have a root component. Where both paths have a
+   ;; root component then it is implementation dependent if a relative path can
+   ;; be constructed. If this path and the given path are equal then an empty
+   ;; path is returned.
+   (-> (.relativize other-path path)
+       .toFile
+       .getCanonicalFile)))
+
+(defn file-locations
+  "Return a vector of possible locations for js-path.
+
+  Output-dir and js-path itself are strings and the returned locations
+  will be the absolute path enclosed in java.io.File instances."
+  [output-dir js-path]
+  (let [js-jpath (or (utils/uri-path js-path) ;; try first if it converts from a URI
+                     (.toPath (io/file js-path)))]
+    (assert (.isAbsolute js-jpath)
+            (format "Foreign Javascript path must be absolute, got %s instead." js-path))
+    (let [cwd-local-jpath (relativize-local js-jpath)]
+      (cond-> []
+        (not (.isAbsolute cwd-local-jpath)) (conj (io/file output-dir cwd-local-jpath))
+        ;; boot always passes the full path
+        (.isAbsolute js-jpath) (conj (.toFile js-jpath))))))
 
 ;; extremely tenuous relationship, this could break easily
 ;; file-path is a string and it is an absolute path
 (defn cljs-target-file-from-foreign [output-dir file-path]
-  (first (filter #(.exists %)
-                 ;; try the projected location
-                 [(io/file output-dir (utils/relativize-local file-path))
-                  (io/file output-dir (.getName (io/file file-path)))])))
+  (->> file-path
+       (file-locations output-dir)
+       (filter #(.exists %))
+       first))
 
 (defn closure-lib-target-file-for-ns [output-dir namesp]
   (let [path (cljs.closure/lib-rel-path {:provides [namesp]})]
@@ -35,7 +71,7 @@
         (and (.exists out-file)
              (safe-js->ns out-file))))))
 
-(defn js-file->namespaces [{:keys [foreign-libs output-dir] :as state} js-file-path]
+(defn js-file->namespaces [{:keys [output-dir] :as state} js-file-path]
   (best-try-js-ns state js-file-path))
 
 (defn hook [build-fn]

--- a/sidecar/src/figwheel_sidecar/utils.clj
+++ b/sidecar/src/figwheel_sidecar/utils.clj
@@ -3,7 +3,8 @@
    [clojure.java.io :as io]
    [cljs.analyzer :as ana]
    [cljs.env]
-   [clojure.string :as string]))
+   [clojure.string :as string])
+  (:import [java.nio.file Path Paths]))
 
 (def sync-agent (agent {}))
 
@@ -115,3 +116,25 @@
        (println line#)
        (Thread/sleep 15))
      result#))
+
+(defn sanitize-path
+  "Return the java.io.File of the input string s."
+  [s]
+  (-> s io/file .getCanonicalPath io/file))
+
+(defn cwd
+  "Return the current \".\" expanded to the actual absolute
+  java.io.File"
+  []
+  (-> "." (java.io.File.) .getCanonicalFile))
+
+(defn uri-path
+  "Return a normalized path when the input string is a valid URI
+  format. Return nil otherwise."
+  [s] ^Path
+  (try
+    (Paths/get (java.net.URI. s))
+    (catch java.net.URISyntaxException e
+      (println " URI syntax exception handled for" s))
+    (catch  java.lang.IllegalArgumentException e
+      (println "Illegal argument exception handled for" s))))

--- a/sidecar/test/figwheel_sidecar/build_middleware/file_reloading_test.clj
+++ b/sidecar/test/figwheel_sidecar/build_middleware/file_reloading_test.clj
@@ -1,0 +1,28 @@
+(ns figwheel-sidecar.build-middleware.file-reloading-test
+  (:require [clojure.java.io :as io]
+            [figwheel-sidecar.utils :as utils]
+            [figwheel-sidecar.build-middleware.javascript-reloading :as js-reloading]
+            [clojure.test :as test :refer [deftest is testing]])
+  (:import [java.nio.file Paths]))
+
+
+(deftest javascript-file-locations
+  (let [output-dir (str (Paths/get "/home" (into-array ["user" ".boot" ".cache" "src" "main.out"])))
+        file (str (Paths/get "/home" (into-array ["user" ".boot" ".cache" "src" "test-namespace" "core.js"])))
+        locations (js-reloading/file-locations output-dir file)]
+    (is (= [file] (map str locations)) "Absolute boot-like path should return absolute file (without throwing, see issue #536)"))
+
+  ;; relative to the current working dir (similar use case: node_modules)
+  (let [output-dir (str (Paths/get "resources" (into-array ["public" "js" "compiled" "out"])))
+        file (str (io/file (utils/cwd) (.toFile (Paths/get "resources" (into-array [ "public" "js" "compiled" "out" "test-namespace" "core.js"])))))
+        locations (js-reloading/file-locations output-dir file)]
+    (is (= [file] (map str locations)) "if already relative to cwd, should return itself."))
+
+  (let [file (str (Paths/get "reagent" (into-array ["core.js"])))]
+    (is (thrown? java.lang.AssertionError (js-reloading/file-locations "" file)) "if the js-path is relative, it should throw an assertion error"))
+
+  ;; Test with file:/ output-dir
+  (let [output-dir (str (Paths/get "resources" (into-array ["public" "js" "compiled" "out"])))
+        file "file:///home/user/project-root/resources/public/js/compiled/out/reagent/core.js"
+        locations (js-reloading/file-locations output-dir file)]
+    (is (= [(-> file utils/uri-path str)] (map str locations)))))


### PR DESCRIPTION
The patch avoids a "is not a relative path" exception, in
javascript-reloading/cljs-target-file-from-foreign.

Fixes #536 and https://github.com/boot-clj/boot-figreload/issues/4