### PR TITLE
Fix figwheel.edn example in README.md

### DIFF
--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -15,7 +15,7 @@ file in the root directory of our project.
   :builds [{:id "example", 
             :source-paths ["src"],
             :figwheel true
-            :build-options
+            :compiler
             {:main example.core,
              :asset-path "js/out",
              :output-to "resources/public/js/example.js",


### PR DESCRIPTION
I got an error from copy-pasting the example figwheel.edn in the README:  "Found unrecognized key :build-options at path (:builds 0)"

It seems :build-options has changed to :compiler.