### PR TITLE
Add :source-map-asset-path option to compiler spec

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -827,6 +827,7 @@ See the Closure Compiler Warning wiki for detailed descriptions.")
      ::externs
      ::modules
      ::source-map-path
+     ::source-map-asset-path
      ::source-map-timestamp
      ::cache-analysis
      ::recompile-dependents


### PR DESCRIPTION
Even though this is a [https://github.com/clojure/clojurescript/wiki/Compiler-Options#source-map-asset-path](valid CLJS compiler option), Figwheel doesn't recognize it. This adds it to the spec so it stops throwing an error when this option is present.