### PR TITLE
only watch existing files and directories fix #451

### DIFF
--- a/sidecar/src/figwheel_sidecar/watching.clj
+++ b/sidecar/src/figwheel_sidecar/watching.clj
@@ -13,7 +13,8 @@
 
 (defn files-and-dirs [source-paths]
   (group-by #(if (.isDirectory %) :dirs :files)
-            (map io/file source-paths)))
+            (->> (map io/file source-paths)
+                 (filter #(.exists %)))))
 
 ;; relies on canonical strings
 (defn is-subdirectory [dir child]


### PR DESCRIPTION
Filtering out source paths that do not exist clears up the NoSuchFileException I see on linux when URLs are specified in`:foreign-libs`. I didn't try the issue @neilmock ran into with META-INF, but have no reason to think it wouldn't work.

I published `[ryfow/figwheel-sidecar "0.5.10-SNAPSHOT"]` to clojars for my personal testing. So folks can try that if they want.