### PR TITLE
Set Cache-Control: no-cache on responses

### DIFF
--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -200,6 +200,13 @@
     #(possible-fn %)
     #(handler %)))
 
+(defn wrap-no-cache [handler]
+  (fn [req]
+    (some-> (handler req)
+      (update :headers assoc
+              "Cache-Control" "no-cache"
+              "Expires" "-1"))))
+
 (defn server
   "This is the server. It is complected and its OK. Its trying to be a basic devel server and
    also provides the figwheel websocket connection."
@@ -217,6 +224,7 @@
      (handle-index            http-server-root)
      (handle-figwheel-websocket server-state)
 
+     (wrap-no-cache)
      ;; adding cors to support @font-face which has a strange cors error
      ;; super promiscuous please don't uses figwheel as a production server :)
      (cors/wrap-cors

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -200,12 +200,21 @@
     #(possible-fn %)
     #(handler %)))
 
-(defn wrap-no-cache [handler]
+(defn wrap-no-cache
+  "Add 'Cache-Control: no-cache' to responses.
+   This allows the client to cache the response, but
+   requires it to check with the server every time to make
+   sure that the response is still valid, before using
+   the locally cached file.
+
+   This avoids stale files being served because of overzealous
+   browser caching, while still speeding up load times by caching
+   files."
+  [handler]
   (fn [req]
     (some-> (handler req)
       (update :headers assoc
-              "Cache-Control" "no-cache"
-              "Expires" "-1"))))
+              "Cache-Control" "no-cache"))))
 
 (defn server
   "This is the server. It is complected and its OK. Its trying to be a basic devel server and

--- a/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/figwheel_server.clj
@@ -14,6 +14,7 @@
    [ring.util.response :refer [resource-response] :as response]
    [ring.util.mime-type :as mime]
    [ring.middleware.cors :as cors]
+   [ring.middleware.not-modified :as not-modified]
    [org.httpkit.server :refer [run-server with-channel on-close on-receive send! open?]]
 
    [com.stuartsierra.component :as component]))
@@ -234,6 +235,7 @@
      (handle-figwheel-websocket server-state)
 
      (wrap-no-cache)
+     (not-modified/wrap-not-modified)
      ;; adding cors to support @font-face which has a strange cors error
      ;; super promiscuous please don't uses figwheel as a production server :)
      (cors/wrap-cors


### PR DESCRIPTION
 Cache-Control: no-cache tells the browser that it may cache the response, but it must always revalidate the cached response with the server, before using it. This is [equivalent](https://stackoverflow.com/a/19938619/826486) to setting

    Cache-Control: max-age=0, must-revalidate

`max-age=0` means that the response is always stale, and `must-revalidate` means that the client must always revalidate stale resources.

`Expires: -1` is not needed, all modern browsers support Cache-Control. IE8 (and below?) [treat 'Cache-Control: no-cache' as 'no-store'](https://stackoverflow.com/a/5084395), meaning that they will always revalidate the cache. That seems a small price to pay for the simpler reasoning about caching by only using Cache-Control.

[Chrome dev site](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching) has good information on the current state of the art for HTTP caching.
[Jake Archibald](https://jakearchibald.com/2016/caching-best-practices/#pattern-2-mutable-content-always-server-revalidated) has a good explanation of exactly the caching pattern that we are looking
to employ.

See also https://stackoverflow.com/a/19938619/826486 for more discussion on `Cache-Control: no-cache`.

Based on @tonsky's work on #464, but fixes merge conflicts, and removes Expires: -1.

Fixes #546.