### PR TITLE
Add install-deps key to cljs_options

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -510,6 +510,13 @@ https://anmonteiro.com/2017/03/requiring-node-js-modules-from-clojurescript-name
 
   :npm-deps {:left-pad \"1.1.3\" }")
 
+(def-key ::install-deps boolean?
+
+  "When set to true, the Clojurescript compiler will handle downloading
+the Javascript dependencies defined in the :npm-deps section of the config.
+
+  :install-deps true")
+
 (def-key ::closure-extra-annotations
   (s/every non-blank-string? :min-count 1 :into [] :kind sequential?)
 
@@ -1025,6 +1032,7 @@ See the Closure Compiler Warning wiki for detailed descriptions.")
      ::language-in
      ::language-out
      ::npm-deps
+     ::install-deps
      ::closure-defines
      ::closure-extra-annotations
      ::anon-fn-naming-policy


### PR DESCRIPTION
As of Clojurescript 1.9.854, the compiler no longer automatically downloads javascript dependencies defined in `:npm-deps`.  However, the Clojurescript team [added](https://github.com/clojure/clojurescript/commit/fb8ce05143dac9e9feb602be2544b72c87b337a3) a new flag to the compiler, `:install-deps`, that, when set to true, will download the JS dependencies for you.

This PR adds the `:install-deps` key to `cljs_options` to allow users to pass this flag through to the compiler for automatic JS dependency downloading.

Thanks for all your hard work, Bruce!  Let me know if there's anything you'd like me to change or add to this PR :)