### PR TITLE
Only use `loader/safeLoad` in HTML environment

### DIFF
--- a/support/src/figwheel/client/file_reloading.cljs
+++ b/support/src/figwheel/client/file_reloading.cljs
@@ -205,7 +205,7 @@
 
 (def gloader
   (cond
-    (exists? loader/safeLoad)
+    (and (exists? loader/safeLoad) (utils/html-env?))
     #(loader/safeLoad (conv/trustedResourceUrlFromString (str %1)) %2)
     (exists? loader/load) #(loader/load (str %1) %2)
     :else (throw (ex-info "No remote script loading function found." {}))))


### PR DESCRIPTION
The `loader/safeLoad` function relies on [`document` being set](https://github.com/google/closure-library/blob/b9c14c6b7a1cd70e3e009bd0206cc70c890a1b17/closure/goog/net/jsloader.js#L162), which it isn't outside of an HTML env.

This was generating "document undefined" errors in React Native envs.