### PR TITLE
Add :cljs-build-fn to the lein-project schema

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -69,7 +69,8 @@
     ::ansi-color-output
     ::builds
     ::reload-clj-files
-    ::hawk-options])
+    ::hawk-options
+    ::cljs-build-fn])
   "A Map of options that determine the behavior of the Figwheel system.
 
   :figwheel {


### PR DESCRIPTION
According to the CHANGELOG since 0.5.0 the build-fn can be specified from the config, but the schema validation wasn't aware of it, so actually doing so would result in an error. This adds it to the schema so the option is recognized.

If this is good to go maybe we can also document it on https://github.com/bhauman/lein-figwheel/wiki/Configuration-Options?

Thanks!