### PR TITLE
FEATURE: configurable wait time for file changes

### DIFF
--- a/sidecar/resources/conf-fig-docs/FigwheelOptions.txt
+++ b/sidecar/resources/conf-fig-docs/FigwheelOptions.txt
@@ -140,3 +140,10 @@ to prevent ANSI color codes in figwheel output set :ansi-color-output
 to false.  Default: true
 
   :ansi-color-output false
+
+:wait-time-ms
+
+The number of milliseconds to wait before issuing reloads. Set this higher
+to wait longer for changes. Default: 50
+
+  :wait-time-ms 50

--- a/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
+++ b/sidecar/src/figwheel_sidecar/components/cljs_autobuild.clj
@@ -277,7 +277,8 @@
                  (watching/watch!
                   (:hawk-options figwheel-server)
                   (source-paths-that-affect-build build-config)
-                  (partial execute-build this)))))
+                  (partial execute-build this)
+                  (:wait-time-ms figwheel-server)))))
       this))
   (stop [this]
     (when (:file-watcher this)

--- a/sidecar/src/figwheel_sidecar/components/file_system_watcher.clj
+++ b/sidecar/src/figwheel_sidecar/components/file_system_watcher.clj
@@ -36,7 +36,8 @@
                          (fn []
                            (utils/bind-logging
                             log-writer
-                            (notification-handler this files))))))))
+                            (notification-handler this files)))))
+                      (:wait-time-ms figwheel-server-options))))
             (do
               (println "Figwheel: No watch paths configured for" watcher-name)
               this)))

--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -70,7 +70,9 @@
     ::builds
     ::reload-clj-files
     ::hawk-options
-    ::cljs-build-fn])
+    ::cljs-build-fn
+    ::wait-time-ms])
+
   "A Map of options that determine the behavior of the Figwheel system.
 
   :figwheel {
@@ -309,6 +311,13 @@ to false.  Default: true
 be useful for certain docker environments.
 
   :hawk-options {:watcher :polling}" )
+
+(def-key ::wait-time-ms integer?
+
+  "The number of milliseconds to wait before issuing reloads. Set this higher
+to wait longer for changes. Default: 50
+
+  :wait-time-ms 50")
 
 (def-key ::reload-clj-files
   (s/or


### PR DESCRIPTION
Closes #569 

Adds a `:wait-time-ms` option to the figwheel configuration map. Allows a user to tune how long before reloads happen.

I left the old signature for `watch!` in the event that it was used elsewhere, but I can remove it if it's not needed.