### PR TITLE
Allow exception messages to wrap in heads up display

### DIFF
--- a/support/src/figwheel/client/heads_up.cljs
+++ b/support/src/figwheel/client/heads_up.cljs
@@ -209,7 +209,7 @@
                                 ": ") "")
                         "<span style=\"font-weight:bold;\">" (escape message) "</span>")
                    (when display-ex-data
-                     (str "<pre>" (utils/pprint-to-string display-ex-data) "</pre>"))
+                     (str "<pre style=\"white-space: pre-wrap\">" (utils/pprint-to-string display-ex-data) "</pre>"))
                    (when (pos? (count error-inline))
                      (format-inline-error error-inline))]
                   (map #(str (escape (:class %))


### PR DESCRIPTION
This is a *very* minor change that allows users to read the entire exception message and detail when it is long.

Currently it looks like this:

<img width="666" alt="current" src="https://user-images.githubusercontent.com/1177083/34050332-4f0e1b5c-e16f-11e7-8834-ea766868bf04.png">

With the change it looks like this:

<img width="662" alt="with-patch" src="https://user-images.githubusercontent.com/1177083/34050334-5182ced2-e16f-11e7-8a35-2cbd288acda6.png">

