### PR TITLE
Execute prep-tasks before figwheel start

### DIFF
--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -45,9 +45,11 @@
 
 ;; well this is private in the leiningen.cljsbuild ns
 (defn- run-local-project [project paths-to-add requires form]
+  (leval/prep project)
   (let [project' (-> project
                    (update-in [:dependencies] conj ['figwheel-sidecar _figwheel-version_])
                    (update-in [:dependencies] conj ['figwheel _figwheel-version_])
+                   (update-in [:resource-path] conj (:compile-path project))
                    (make-subproject paths-to-add))]
     (eval-and-catch project' requires form)))
 


### PR DESCRIPTION
Hey,
I had the same problem like author of this issue: https://github.com/bhauman/lein-figwheel/issues/68 and found a way how to force lein-figwheel to compile java sources and add it to project.
Just slight change.
 I'm not familiar with leiningen plugins, so probably someone more experienced should check if this solution is acceptable.