### PR TITLE
Add doc for :before-jsload client hook

### DIFF
--- a/sidecar/resources/conf-fig-docs/FigwheelClientOptions.txt
+++ b/sidecar/resources/conf-fig-docs/FigwheelClientOptions.txt
@@ -27,6 +27,14 @@ Default: Off
 
   :on-jsload "example.core/fig-reload"
 
+:before-jsload
+
+A String or Symbol representing a client side ClojureScript function
+to be invoked before new code has been loaded.
+Default: Off
+
+  :before-jsload "example.core/fig-teardown"
+
 :heads-up-display
 
 Show a notification in the browser on each refresh.


### PR DESCRIPTION
I found that there is no description of this hook anywhere. 

Probably it would be also helpful if it was mentioned here https://github.com/bhauman/lein-figwheel#writing-reloadable-code or here https://github.com/bhauman/lein-figwheel/wiki/Configuration-Options. What do you think?