### PR TITLE
Fix function parameters in 'figwheel-sidecar.system/repl-function-docs'

### DIFF
--- a/sidecar/src/figwheel_sidecar/system.clj
+++ b/sidecar/src/figwheel_sidecar/system.clj
@@ -486,13 +486,13 @@
 (def repl-function-docs
   "Figwheel Controls:
           (stop-autobuild)                ;; stops Figwheel autobuilder
-          (start-autobuild [id ...])      ;; starts autobuilder focused on optional ids
+          (start-autobuild id ...)        ;; starts autobuilder focused on optional ids
           (switch-to-build id ...)        ;; switches autobuilder to different build
           (reset-autobuild)               ;; stops, cleans, and starts autobuilder
           (reload-config)                 ;; reloads build config and resets autobuild
-          (build-once [id ...])           ;; builds source one time
-          (clean-builds [id ..])          ;; deletes compiled cljs target files
-          (print-config [id ...])         ;; prints out build configurations
+          (build-once id ...)             ;; builds source one time
+          (clean-builds id ..)            ;; deletes compiled cljs target files
+          (print-config id ...)           ;; prints out build configurations
           (fig-status)                    ;; displays current state of system
           (figwheel.client/set-autoload false)    ;; will turn autoloading off
           (figwheel.client/set-repl-pprint false) ;; will turn pretty printing off


### PR DESCRIPTION
The REPL function doc string does not accurately reflect the signatures of the functions in 'repl-api.clj'. Namely, the functions which accept a variable number of build 'ids' all have a signature identical to this one:
**repl-api.clj**
```
(defn switch-to-build
  "Stops the currently running autobuilder and starts building the
builds with the provided ids."
  [& ids]
  (app-trans fs/switch-to-build ids))
```
If you try to pass a vector of 'ids', as 'repl-function-docs' suggests, you will get an exception in 'system/namify' as it calls 'clojure.core/name' on a vector.

Since there is no need to call the functions this way, and I presume it has never actually worked this way, I just went and changed the docs.