### PR TITLE
Cljs 1.10.x worker target support

### DIFF
--- a/sidecar/src/figwheel_sidecar/build_middleware/injection.clj
+++ b/sidecar/src/figwheel_sidecar/build_middleware/injection.clj
@@ -11,6 +11,10 @@
   (when-let [target (get-in build [:build-options :target])]
     (= target :nodejs)))
 
+(defn- webworker? [build]
+  (when-let [target (get-in build [:build-options :target])]
+    (= target :webworker)))
+
 (defn- has-main? [build]
   (get-in build [:build-options :main]))
 
@@ -41,7 +45,8 @@
                      (fnil conj [])
                      (if (and (has-main? build)
                               (not (has-modules? build))
-                              (not (node? build)))
+                              (not (node? build))
+                              (not (webworker? build)))
                        'figwheel.connect
                        'figwheel.preload))
           (update-in [:build-options :external-config :figwheel/config] #(if % % (get build :figwheel {})))
@@ -70,7 +75,7 @@
 
 (defn append-src-script [build src-code]
   (let [output-to (has-output-to? build)
-        line (if (and (has-main? build) (not (node? build)))
+        line (if (and (has-main? build) (not (node? build)) (not (webworker? build)))
                (str (document-write-src-script src-code))
                (format "\n%s" src-code))]
     (when (and output-to (.exists (io/file output-to)))
@@ -80,7 +85,8 @@
   (when (and (config/figwheel-build? build)
              (has-main? build)
              (not (has-modules? build))
-             (not (node? build)))
+             (not (node? build))
+             (not (webworker? build)))
     (append-src-script build "figwheel.connect.start();")))
 
 (defn hook [build-fn]

--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -159,7 +159,7 @@ human-readable manner. Defaults to true.
 
   :pretty-print false")
 
-(def-key ::target                    #{:nodejs}
+(def-key ::target                    #{:nodejs :webworker}
 
   "If targeting nodejs add this line. Takes no other options at the
 moment. The default (no :target specified) implies browsers are being

--- a/support/src/figwheel/client/utils.clj
+++ b/support/src/figwheel/client/utils.clj
@@ -18,3 +18,8 @@
 (defmacro dev-assert [& body]
   `(dev
      ~@(map (fn [pred-stmt] `(assert ~pred-stmt)) body)))
+
+(defmacro feature?
+  [obj feature]
+  `(and (cljs.core/exists? ~obj)
+        (cljs.core/exists? (cljs.core/aget ~obj ~feature))))

--- a/support/src/figwheel/client/utils.cljs
+++ b/support/src/figwheel/client/utils.cljs
@@ -7,7 +7,8 @@
             [goog.userAgent.product :as product])
   (:import [goog]
            [goog.async Deferred]
-           [goog.string StringBuffer]))
+           [goog.string StringBuffer])
+  (:require-macros [figwheel.client.utils :refer [feature?]]))
 
 ;; don't auto reload this file it will mess up the debug printing
 
@@ -109,12 +110,6 @@
                                    (fin v))))))
              deferred coll)
      (fn [_] (.succeed Deferred @results)))))
-
-
-(defn- feature? [obj feature]
-  (and (exists? obj)
-       (exists? (aget obj feature))))
-
 
 ;; persistent storage of configuration keys
 


### PR DESCRIPTION
As of https://github.com/clojure/clojurescript/commit/e380903ba9af1ce9dd25691cccc1fb62c1a38d5b, ClojureScript is getting a proper compiler `:target` option for WebWorkers: `:webworker`.

This is great, as it means the [hacky process I outlined here](https://github.com/bhauman/lein-figwheel/wiki/Using-Figwheel-with-Web-Workers) will no longer be necessary, since worker builds with `:optimizations :none` can now set a `:main`. The flipside is that figwheel needs to expect such cases during pre-compilation steps and script injection.

This pull:
*  Adds `:webworker` to the valid targets in the spec
*  Shadows the node checks during injection for workers
*  Addresses an odd behavior where the `feature?` check during the definition of `local-persistent-config` throws a runtime error. ~~Since this check is present in previous versions of figwheel that work fine with workers, and the same check runs fine inside a function, I'm guessing it has something to do with changes to the cljs compiler, so my fix for this should be regarded with suspicion.~~

I realize that this might be a little premature given how new the worker support in Cljs is, but at the very least I hope it is informative! Thanks again for figwheel!
