### PR TITLE
Add ETag to static files

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -10,6 +10,8 @@
          :url "https://github.com/bhauman/lein-figwheel"
          :dir ".."}
 
+  :jvm-opts ^:replace ["-Xms256m" "-Xmx2g"]
+
   :profiles {:dev {:dependencies [[leiningen "2.8.1"]
                                   [com.bhauman/rebel-readline-cljs "0.1.1"]
                                   [org.clojure/test.check "0.9.0"]]

--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -22,6 +22,7 @@
     :exclusions
     [org.clojure/tools.reader
      org.clojure/clojure]]
+   [co.deps/ring-etag-middleware "0.2.0"]
    [clj-stacktrace "0.2.8"]
    [figwheel "0.5.16-SNAPSHOT"
       :exclusions [org.clojure/tools.reader]]

--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -35,6 +35,8 @@
 
   :clean-targets ^{:protect false} ["dev-resources/public/js" "target"]
 
+  :jvm-opts ^:replace ["-Xms256m" "-Xmx2g"]
+
   :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.2"]]
                    :source-paths ["cljs_src" "src" "dev"]
                    :plugins [[lein-cljsbuild "1.1.3" :exclusions [[org.clojure/clojure]]]

--- a/sidecar/src/figwheel_sidecar/utils.clj
+++ b/sidecar/src/figwheel_sidecar/utils.clj
@@ -115,3 +115,17 @@
        (println line#)
        (Thread/sleep 15))
      result#))
+
+(defn dissoc-in
+  "Dissociates an entry from a nested associative structure returning a new
+  nested structure. keys is a sequence of keys. Any empty maps that result
+  will not be present in the new structure."
+  [m [k & ks :as keys]]
+  (if ks
+    (if-let [nextmap (get m k)]
+      (let [newmap (dissoc-in nextmap ks)]
+        (if (seq newmap)
+          (assoc m k newmap)
+          (dissoc m k)))
+      m)
+    (dissoc m k)))

--- a/support/project.clj
+++ b/support/project.clj
@@ -6,6 +6,7 @@
   :scm {:name "git"
         :url "https://github.com/bhauman/lein-figwheel"
         :dir ".."}
+  :jvm-opts ^:replace ["-Xms256m" "-Xmx2g"]
   :dependencies
   [[org.clojure/clojure "1.8.0"]
    [org.clojure/clojurescript "1.9.946"


### PR DESCRIPTION
- Calculate checksum for each file when serving it
- If the file system supports it, store checksum as extended attributes
on the file to reuse it on the next request

This is still a WIP, there are a few things to work out here before merging. However I'm interested in the overall approach, namely:

* Calculating a checksum for files to use as an ETag
* Storing the checksum in extended file attributes if the OS supports it (Windows and Linux do, macOS [doesn't](https://bugs.openjdk.java.net/browse/JDK-8030048) currently)


Fixes #664