### PR TITLE
Update for :npm-deps false and latest :npm-deps docs

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -511,9 +511,12 @@ For :optimization :none, a :main option must be specified for defines
 to work, and only goog-define defines are affected. :closure-defines
 currently does not have any effect with :optimization :whitespace.")
 
-(def-key ::npm-deps (s/map-of ::string-or-named string?)
-  "Please see:
-https://anmonteiro.com/2017/03/requiring-node-js-modules-from-clojurescript-namespaces/
+(def-key ::npm-deps (s/or :map   (s/map-of ::string-or-named string?)
+                          :false false?)
+  "Declare NPM dependencies. A map of NPM package names to the desired
+versions or the Boolean value false. If false then any existing
+node_modules directory will not be indexed nor used. See also
+:install-deps.
 
   :npm-deps {:left-pad \"1.1.3\" }")
 


### PR DESCRIPTION
Allow `:npm-deps` to additionally take on the value of `false`. This is allowed with ClojureScipt 1.10.238 (see https://github.com/clojure/clojurescript/commit/486de1a8b0836dbe3a622662a69f57aa92d232de)

Also update the doc string to match the `:npm-deps` site documentation (https://clojurescript.org/reference/compiler-options#npm-deps)