### PR TITLE
Warn about lein trampoline being broken on Windows

### DIFF
--- a/plugin/src/leiningen/figwheel.clj
+++ b/plugin/src/leiningen/figwheel.clj
@@ -555,10 +555,9 @@ Configuration:
              (or (= nil command)
                  (= ":reactor" command))
              (get-in project [:figwheel :repl] true)
-             (get-in project [:figwheel :readline] true))
-          (if tramp/*trampoline?*
-            (launch-figwheel command project build-ids)
-            (do
-              (warn-about-broken-trampoline-on-windows)
-              (apply tramp/trampoline project "figwheel" command-and-or-build-ids)))
+             (get-in project [:figwheel :readline] true)
+             (not tramp/*trampoline?*))
+          (do
+            (warn-about-broken-trampoline-on-windows)
+            (apply tramp/trampoline project "figwheel" command-and-or-build-ids))
           (launch-figwheel command project build-ids))))))


### PR DESCRIPTION
See issue #682.

I've tested this locally on my project, in Windows. With trampoline being invoked I see this warning and the corresponding breakage. With `:readline false` I do not see this warning and nor do I see breakage.

I have not tested this on other OSs.

One consideration is whether there are Windows users who have found some other workaround for this issue and who would be annoyed by the banner. I don't know if that's the case - but weighing up an annoyance for some vs incomprehensible breakage for others...I think I personally care more about the latter.