### PR TITLE
Test new projects and test against JDK 10 and 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,29 @@
+defaults: &defaults
+  working_directory: ~/lein-figwheel
+  environment:
+    LEIN_ROOT: nbd
+    JVM_OPTS: -Xmx3200m
+  steps:
+    - checkout
+    - run: scripts/dependency-checksum
+    - restore_cache:
+        key: figwheel-v1-{{ checksum "checksum.tmp" }}
+    - run:
+        name: Test all projects
+        command: scripts/test-all
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: figwheel-v1-{{ checksum "checksum.tmp" }}
+
 version: 2
 jobs:
-  build:
-    working_directory: ~/lein-figwheel
+  build-lein-2.7.1:
+    <<: *defaults
     docker:
       - image: circleci/clojure:lein-2.7.1
-    environment:
-      LEIN_ROOT: nbd
-      JVM_OPTS: -Xmx3200m
-    steps:
-      - checkout
-      - run: scripts/dependency-checksum
-      - restore_cache:
-          key: figwheel-v1-{{ checksum "checksum.tmp" }}
-      - run:
-          name: Test all projects
-          command: scripts/test-all
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: figwheel-v1-{{ checksum "checksum.tmp" }}
+workflows:
+  version: 2
+  build-all:
+    jobs:
+      - build-lein-2.7.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,13 @@ jobs:
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
-      # See https://discuss.circleci.com/t/cant-checksum-multiple-files-with-slashes-in-the-file-path/20667 for why we do this:
-      - run: shasum sidecar/project.clj plugin/project.clj support/project.clj > checksum.tmp
+      - run: scripts/dependency-checksum
       - restore_cache:
-          key: figwheel-{{ checksum "checksum.tmp" }}
-      - run: scripts/install
+          key: figwheel-v1-{{ checksum "checksum.tmp" }}
+      - run:
+          name: Test all projects
+          command: scripts/test-all
       - save_cache:
           paths:
             - ~/.m2
-          key: figwheel-{{ checksum "checksum.tmp" }}
-      - run:
-          name: Test plugin
-          command: lein test
-          working_directory: plugin
-      - run:
-          name: Test sidecar
-          command: lein test
-          working_directory: sidecar
-      - run:
-          name: Test support
-          command: lein test
-          working_directory: support
-
+          key: figwheel-v1-{{ checksum "checksum.tmp" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ defaults: &defaults
     - restore_cache:
         key: figwheel-v1-{{ checksum "checksum.tmp" }}
     - run:
+        name: Install all JARs
+        command: scripts/install
+    - run:
         name: Test all projects
         command: scripts/test-all
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ defaults: &defaults
     JVM_OPTS: -Xmx3200m
   steps:
     - checkout
+    - run: scripts/install-lein
     - run: scripts/dependency-checksum
     - restore_cache:
         key: figwheel-v1-{{ checksum "checksum.tmp" }}
@@ -14,16 +15,27 @@ defaults: &defaults
     - save_cache:
         paths:
           - ~/.m2
+          - ~/.lein/self-installs
         key: figwheel-v1-{{ checksum "checksum.tmp" }}
 
 version: 2
 jobs:
-  build-lein-2.7.1:
+  build-jdk-8:
     <<: *defaults
     docker:
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/openjdk:8-node
+  build-jdk-10:
+    <<: *defaults
+    docker:
+      - image: circleci/openjdk:10-node
+  build-jdk-11:
+    <<: *defaults
+    docker:
+      - image: circleci/openjdk:11-ea-node-browsers
 workflows:
   version: 2
   build-all:
     jobs:
-      - build-lein-2.7.1
+      - build-jdk-8
+      - build-jdk-10
+      - build-jdk-11

--- a/scripts/dependency-checksum
+++ b/scripts/dependency-checksum
@@ -5,4 +5,4 @@ set -ex
 # See https://discuss.circleci.com/t/cant-checksum-multiple-files-with-slashes-in-the-file-path/20667 for why we do this:
 # Calculates checksums for all Figwheel project dependencies.
 
-shasum sidecar/project.clj plugin/project.clj support/project.clj figwheel-core/deps.edn figwheel-main/deps.edn figwheel-repl/deps.edn > checksum.tmp
+shasum sidecar/project.clj plugin/project.clj support/project.clj figwheel-core/deps.edn figwheel-main/deps.edn figwheel-repl/deps.edn /usr/local/bin/lein > checksum.tmp

--- a/scripts/dependency-checksum
+++ b/scripts/dependency-checksum
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+# See https://discuss.circleci.com/t/cant-checksum-multiple-files-with-slashes-in-the-file-path/20667 for why we do this:
+# Calculates checksums for all Figwheel project dependencies.
+
+shasum sidecar/project.clj plugin/project.clj support/project.clj figwheel-core/deps.edn figwheel-main/deps.edn figwheel-repl/deps.edn > checksum.tmp

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+# We install all JARs so that cross project dependencies work correctly.
+for project in "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"; do
+  pushd ${project}
+  lein install
+  popd
+done

--- a/scripts/install
+++ b/scripts/install
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-pushd support ; lein install ; popd
-pushd sidecar ; lein install ; popd
-pushd plugin ; lein install ; popd
-

--- a/scripts/install
+++ b/scripts/install
@@ -3,7 +3,7 @@
 set -ex
 
 # We install all JARs so that cross project dependencies work correctly.
-for project in "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"; do
+for project in "figwheel-repl" "figwheel-core" "figwheel-main" "plugin" "sidecar" "support"; do
   pushd ${project}
   lein install
   popd

--- a/scripts/install-lein
+++ b/scripts/install-lein
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+# Used for CircleCI so that we can have a build matrix of multiple JDK's to test against.
+# The Clojure images they provide only have a single JDK 8 available.
+sudo wget -O /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+sudo chmod a+x /usr/local/bin/lein

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -2,7 +2,8 @@
 
 set -ex
 
-for project in "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"; do
+# "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"
+for project in "plugin" "sidecar" "support"; do
   pushd ${project}
   lein test
   popd

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -2,14 +2,8 @@
 
 set -ex
 
-for project in "figwheel-main"; do
-  pushd ${project}
-  make testit
-  popd
-done
-
-# TODO: add "figwheel-core"
-for project in "figwheel-repl" "plugin" "sidecar" "support"; do
+# TODO: add "figwheel-core" "figwheel-main"
+for project in  "figwheel-repl" "plugin" "sidecar" "support"; do
   pushd ${project}
   lein test
   popd

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -2,8 +2,7 @@
 
 set -ex
 
-# "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"
-for project in "plugin" "sidecar" "support"; do
+for project in "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"; do
   pushd ${project}
   lein test
   popd

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -2,7 +2,14 @@
 
 set -ex
 
-for project in "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"; do
+for project in "figwheel-main"; do
+  pushd ${project}
+  make testit
+  popd
+done
+
+# TODO: add "figwheel-core"
+for project in "figwheel-repl" "plugin" "sidecar" "support"; do
   pushd ${project}
   lein test
   popd

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+for project in "figwheel-core" "figwheel-main" "figwheel-repl" "plugin" "sidecar" "support"; do
+  pushd ${project}
+  lein test
+  popd
+done


### PR DESCRIPTION
This PR tests the new figwheel-* projects and also runs tests against JDK 8, 10, and 11. This should hopefully catch regressions in new JDKs. It looks like there are some failing tests in the new figwheel-* projects, so I've added them in in a separate commit so you can see that the overall approach works.