### PR TITLE
Bump to cider/piggieback

### DIFF
--- a/sidecar/project.clj
+++ b/sidecar/project.clj
@@ -37,7 +37,7 @@
 
   :jvm-opts ^:replace ["-Xms256m" "-Xmx2g"]
 
-  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.2"]]
+  :profiles {:dev {:dependencies [[cider/piggieback "0.4.0"]]
                    :source-paths ["cljs_src" "src" "dev"]
                    :plugins [[lein-cljsbuild "1.1.3" :exclusions [[org.clojure/clojure]]]
                              [lein-ancient "0.6.15"]]}

--- a/sidecar/resources/conf-fig-docs/FigwheelOptions.txt
+++ b/sidecar/resources/conf-fig-docs/FigwheelOptions.txt
@@ -117,7 +117,7 @@ specifies which local network interface you want to launch the server on.
 A vector of strings indicating the nREPL middleware you want included
 when nREPL launches.
 
-  :nrepl-middleware ["cider.nrepl/cider-middleware" "cemerick.piggieback/wrap-cljs-repl"]
+  :nrepl-middleware ["cider.nrepl/cider-middleware" "cider.piggieback/wrap-cljs-repl"]
 
 :validate-config
 

--- a/sidecar/src/figwheel_sidecar/components/nrepl_server.clj
+++ b/sidecar/src/figwheel_sidecar/components/nrepl_server.clj
@@ -17,8 +17,8 @@
                       (cond
                         (utils/require? 'cider.piggieback)
                         ["cider.piggieback/wrap-cljs-repl"]
-                        (utils/require? 'cemerick.piggieback)
-                        ["cemerick.piggieback/wrap-cljs-repl"]
+                        (utils/require? 'cider.piggieback)
+                        ["cider.piggieback/wrap-cljs-repl"]
                         :else nil))
           resolve-mw (fn [name]
                        (let [s (symbol name)
@@ -66,7 +66,7 @@
   :nrepl-middleware a optional list of nREPL middleware to include
 
   This function will attempt to require/load the
-  cemerick.piggieback/wrap-cljs-repl middleware which is needed to
+  cider.piggieback/wrap-cljs-repl middleware which is needed to
   start a ClojureSript REPL over nREPL."
   [options]
   (map->NreplComponent options))

--- a/sidecar/src/figwheel_sidecar/repl.clj
+++ b/sidecar/src/figwheel_sidecar/repl.clj
@@ -172,9 +172,9 @@
       (let [cljs-repl (resolve 'cider.piggieback/cljs-repl)
             opts' (:repl-opts figwheel-env)]
         (apply cljs-repl figwheel-env (apply concat opts')))
-      (and (require? 'cemerick.piggieback)
-           (bound-var? 'cemerick.piggieback/*cljs-repl-env*))
-      (let [cljs-repl (resolve 'cemerick.piggieback/cljs-repl)
+      (and (require? 'cider.piggieback)
+           (bound-var? 'cider.piggieback/*cljs-repl-env*))
+      (let [cljs-repl (resolve 'cider.piggieback/cljs-repl)
             opts' (:repl-opts figwheel-env)]
         (apply cljs-repl figwheel-env (apply concat opts')))
       :else (throw (ex-info "Unable to load a ClojureScript nREPL middleware library" {})))

--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -265,7 +265,7 @@ specifies which local network interface you want to launch the server on.
   "A vector of strings indicating the nREPL middleware you want included
 when nREPL launches.
 
-  :nrepl-middleware [\"cider.nrepl/cider-middleware\" \"cemerick.piggieback/wrap-cljs-repl\"]")
+  :nrepl-middleware [\"cider.nrepl/cider-middleware\" \"cider.piggieback/wrap-cljs-repl\"]")
 
 (def-key ::validate-config   (some-fn boolean? #{:warn-unknown-keys :ignore-unknown-keys})
 


### PR DESCRIPTION
Allows use with Leiningen 2.9.1.

This would allow upgrading projects that still use lein-figwheel to work with Leiningen 2.9.1, which brings nrepl/nrepl (mentioning the organization here for clarity).

On a related note, upgrading org.clojure/tools.nrepl to nrepl/nrepl as discussed in #718 might also be in order, although I guess the newer nrepl get's bundled in when used with Leiningen 2.9.1.