### PR TITLE
add support for :fingerprint compiler option

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/cljs_options.clj
@@ -671,6 +671,13 @@ This setting does not apply if :optimizations is set to :advanced.
 
   :checked-arrays :warn")
 
+(def-key ::fingerprint boolean?
+  "Append content SHA to output file names.
+A manifest.edn file is emitted to :output-dir for mapping to fingerprinted filenames.
+Defaults to false.
+
+  :fingerprint true")
+
 ;; ** ClojureScript Compiler Warnings
 
 (def-key ::warnings
@@ -1115,6 +1122,7 @@ See the Closure Compiler Warning wiki for detailed descriptions.")
      ::rewrite-polyfills
      ::checked-arrays
      ::aot-cache
+     ::fingerprint
 
      ;; these need definitions above
      ::closure-variable-map-out


### PR DESCRIPTION
Add support for a `:fingerprint` compiler option, which was added with [ClojureScript 1.10.439](https://cljs.github.io/api/compiler-options/fingerprint)