### PR TITLE
Don't try to open cljs file if it doesn't exist

### DIFF
--- a/sidecar/src/figwheel_sidecar/build_middleware/javascript_reloading.clj
+++ b/sidecar/src/figwheel_sidecar/build_middleware/javascript_reloading.clj
@@ -31,7 +31,7 @@
                    (safe-js->ns js-file-path))]
     (if-not (empty? provs)
       provs
-      (let [out-file (cljs-target-file-from-foreign (:output-dir state) js-file-path)]
+      (if-let [out-file (cljs-target-file-from-foreign (:output-dir state) js-file-path)]
         (and (.exists out-file)
              (safe-js->ns out-file))))))
 


### PR DESCRIPTION
lein-figwheel expects files with .js extension inside its source
directories to be foreign libraries. And foreign libraries must 
declare a namespace. In fact, lein-figwheel assumes it, and if it
doesn't find it and can't map the file back to a source .cljs file, it
bombs out with a NullPointerException when trying to check for its
existance.

This might happen when you put your externs file(s) inside the source
directories (this is in fact the case that led to the discovery of
this issue).

While lein-figwheel doesn't by default try to process such files on
its own, when using [Duct server.figwheel](https://github.com/duct-framework/server.figwheel)
it tells lein-figwheel to proccess all files inside the configured source
directories (see
https://github.com/duct-framework/server.figwheel/blob/master/src/duct/server/figwheel.clj#L54-L55).

Clearly Duct server.figwheel shouldn't be telling lein-figwheel to
process absolutely all files in source directories (but probably just
those having .cljs/cljc extension or those declared as foreign
libraries[1]).

But on the other hand, lein-figwheel should be more robust and handle
that situation in a more graceful way.

[1] We have opened an issue in Duct server.figwheel regarding this behaviour.