### PR TITLE
Allow `:hawk-options` to take `:sensitivity` config.

### DIFF
--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -317,7 +317,13 @@ to false.  Default: true
 
   :ansi-color-output false")
 
-(def-key ::hawk-options (s/map-of #{:watcher} #{:barbary :java :polling})
+(def-key ::hawk-options
+  (s/every
+    (fn [[k v]]
+      (contains?
+        (-> {:watcher #{:barbary :java :polling}
+             :sensitivity #{:low :medium :high}})
+        v)))
 
   "If you need to watch files with polling instead of FS events. This can
 be useful for certain docker environments.

--- a/sidecar/src/figwheel_sidecar/schemas/config.clj
+++ b/sidecar/src/figwheel_sidecar/schemas/config.clj
@@ -322,7 +322,8 @@ to false.  Default: true
     (fn [[k v]]
       (contains?
         (-> {:watcher #{:barbary :java :polling}
-             :sensitivity #{:low :medium :high}})
+             :sensitivity #{:low :medium :high}}
+          (get k))
         v)))
 
   "If you need to watch files with polling instead of FS events. This can


### PR DESCRIPTION
When trying to use the config: 

```
  :hawk-options {:watcher :polling :sensitivity :low}
```

the following error is produced:

```
...
------ Figwheel Configuration Error ------

Error at [:figwheel :hawk-options :sensitivity 0]
The key :sensitivity at (:figwheel :hawk-options) does not conform.
It should satisfy #{:watcher}


-- Docs for key :hawk-options --
If you need to watch files with polling instead of FS events. This can
be useful for certain docker environments.

  :hawk-options {:watcher :polling}
...
```

The schema spec is only checking `:watcher` with possible values `#{:barbary :java :polling}` 

This change allows specifying `:sensitivity` with it's possible values `#{:low :medium :high}` as well.